### PR TITLE
build(deps): bump navigation3-runtime, logback, and bcprov

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ kover = "0.9.9"
 # Jetpack
 androidx-activity = "1.13.0"
 androidx-lifecycle = "2.11.0"
-androidx-navigation3-runtime = "1.1.5"
+androidx-navigation3-runtime = "1.1.6"
 androidx-navigation3-ui = "1.1.1"
 androidx-adaptive = "1.3.0-beta02"
 androidx-room = "3.0.1"
@@ -32,7 +32,7 @@ kotlinx-binary-compatibility-validator = "0.18.1"
 kermit = "2.1.0"
 slf4j = "2.0.18"
 slf4j-android = "2.0.17-0"
-logback = "1.6.1"
+logback = "1.6.3"
 
 # Test
 androidx-test-core = "1.7.0"
@@ -41,7 +41,7 @@ androidx-test-espresso-core = "3.7.0"
 junit = "4.13.2"
 robolectric = "4.16.1"
 # Constraint-only: robolectric 4.16.1 pins bcprov 1.81 (GHSA-574f-3g2m-x479); remove once robolectric ships >= 1.84.
-bouncycastle = "1.85"
+bouncycastle = "1.85.2"
 
 [libraries]
 # Build


### PR DESCRIPTION
Pre-release dependency refresh — all three moved to their latest stable releases.

| Dependency | From | To |
|---|---|---|
| `androidx-navigation3-runtime` | 1.1.5 | 1.1.6 |
| `logback` | 1.6.1 | 1.6.3 |
| `bouncycastle` | 1.85 | 1.85.2 |

Notes:
- Stayed on the stable nav3 1.1.x line; `1.2.0-alpha07` is available but not taken.
- `bouncycastle` remains constraint-only: robolectric 4.16.1 still pins bcprov 1.81, and the constraint was confirmed to force `1.81 -> 1.85.2` on the Android unit-test classpath, so the existing comment stays accurate.

## Verification
- `./gradlew jvmTest` — green
- `./gradlew :androidApp:assembleDebug :desktopApp:compileKotlin` — green
- `./gradlew apiCheck` — green (no dump changes needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)