### PR TITLE
chore: release 1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.0] - 2026-08-18
+
 ### Added
 - Postings now carry data-layer sync metadata: `updatedAt` (client write time in epoch milliseconds), `isDeleted` (soft-delete tombstone), and `pendingSync` (changed locally, not yet replicated). The columns exist on `PostingEntity` only — the domain `Posting` is still id + narrative, and the mappers deliberately drop them — and `OfflineFirstPostingRepository` stamps `updatedAt` and `pendingSync` on every insert and update from an injected `kotlin.time.Clock` (`Clock.System` in production, a fixed clock in tests).
 - `PostingDao` gained replication-facing queries that the app itself never calls: `getPendingSync()`, `getByIds()`, `upsert()`, `clearPendingSyncIfUnchanged()`, and `hardDeleteById()`. They exist so a replication layer can be added on top of this DAO without reopening the entity or the schema, and they are covered by tests so the last-write-wins contract lives in one place. Two details worth knowing: `upsert()` uses `@Insert(onConflict = REPLACE)` rather than `@Upsert` so it also runs on older SQLite builds such as Robolectric's, and `clearPendingSyncIfUnchanged()` clears the pending flag only while `updatedAt` still matches the value that was read for the push, so an edit made mid-push is replicated next time instead of being lost.
@@ -17,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **The local database schema changed and there is no migration — an existing install must have its app data cleared, or the app reinstalled.** The three columns above were folded into **schema version 1** rather than shipping as version 2 with a migration: this project is a template, and a project generated from it must start at version 1 rather than inherit this repository's release history. Room compares the stored identity hash before any migration logic runs, so an install from 1.6.1–1.6.5 fails to open the database with "Room cannot verify the data integrity…" rather than losing data silently. `fallbackToDestructiveMigration(dropAllTables = true)` does not cover this — it only fires on a version change. `core/database/schemas/…/1.json` was regenerated accordingly and its `identityHash` differs from the previous 1.6.x releases.
 - Deleting a posting is now a soft delete: the row is tombstoned (`isDeleted`, `pendingSync`, and `updatedAt` stamped) instead of being removed, and both DAO reads filter tombstones out, so the UI behaves exactly as before. Tombstones are retained — nothing purges them — which is harmless at this project's scale; `hardDeleteById()` removes a row outright for a replication layer that has confirmed the deletion.
 - The README now states plainly that this is a showcase project, to be used as a template and a reference for new projects rather than as an app to keep data in, and that the local schema may change between releases without a migration path.
+- Upgraded Navigation 3 runtime to 1.1.6 (from 1.1.5), Logback to 1.6.3 (from 1.6.1), and the constraint-only BouncyCastle pin to 1.85.2 (from 1.85) — the latter exists solely to keep Robolectric off the vulnerable 1.81 and is not a runtime dependency.
+- Bumped pinned GitHub Actions: `dorny/paths-filter` v4, `gradle/actions/wrapper-validation` and `gradle/actions/dependency-submission` v6, `actions/attest` v4.2.2, `github/codeql-action/upload-sarif` v4.37.6.
+- Refreshed the README and `CLAUDE.md` tech-stack tables to match `gradle/libs.versions.toml` (Navigation 3 runtime 1.1.6, Logback 1.6.3).
+
+### Removed
+- `PostingDao.deleteById`, replaced by `softDeleteById` (tombstones the row so the deletion can propagate to a replica) and `hardDeleteById` (drops the row outright, tombstone included). `OfflineFirstPostingRepository.deletePosting` now calls `softDeleteById`; no caller outside the data layer used the removed method.
 
 ## [1.6.5] - 2026-08-07
 
@@ -203,7 +211,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Clean Architecture implementation.
 - Modular feature structure.
 
-[Unreleased]: https://github.com/aoreshkov/kmp-ledger/compare/v1.6.5...HEAD
+[Unreleased]: https://github.com/aoreshkov/kmp-ledger/compare/v1.7.0...HEAD
+[1.7.0]: https://github.com/aoreshkov/kmp-ledger/compare/v1.6.5...v1.7.0
 [1.6.5]: https://github.com/aoreshkov/kmp-ledger/compare/v1.6.4...v1.6.5
 [1.6.4]: https://github.com/aoreshkov/kmp-ledger/compare/v1.6.3...v1.6.4
 [1.6.3]: https://github.com/aoreshkov/kmp-ledger/compare/v1.6.2...v1.6.3

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,7 @@ Three composable Gradle plugins — modules declare one of these instead of conf
 | Compose Multiplatform | 1.11.1 |
 | Koin | 4.2.2 |
 | Room | 3.0.1 |
-| Navigation 3 | 1.1.5 (runtime) / 1.1.1 (ui) |
+| Navigation 3 | 1.1.6 (runtime) / 1.1.1 (ui) |
 | AndroidX DataStore | 1.2.1 |
 | Coroutines | 1.11.0 |
 | Kover | 0.9.9 |

--- a/README.md
+++ b/README.md
@@ -64,12 +64,12 @@ study in this repo (`.claude/`, `.github/workflows/`) — pre-wired to your proj
 | Compose Multiplatform | 1.11.1 | Shared UI (Android, iOS, Desktop) |
 | Room 3 / SQLite | 3.0.1 / 2.7.0 | Local database with KMP support |
 | AndroidX DataStore (Preferences) | 1.2.1 | Multiplatform key-value persistence (theme preference) |
-| Navigation 3 | 1.1.5 (runtime) / 1.1.1 (ui) | Type-safe declarative navigation |
+| Navigation 3 | 1.1.6 (runtime) / 1.1.1 (ui) | Type-safe declarative navigation |
 | Material3 Adaptive Navigation Suite | 1.11.0-alpha07 | Adaptive top-level nav (bottom bar / rail / drawer) |
 | Koin | 4.2.2 | Dependency injection with annotation processing |
 | Kermit | 2.1.0 | Kotlin Multiplatform logging |
 | Kover | 0.9.9 | Kotlin Multiplatform code coverage |
-| SLF4J / Logback | 2.0.18 / 1.6.1 | Desktop logging implementation |
+| SLF4J / Logback | 2.0.18 / 1.6.3 | Desktop logging implementation |
 | Swift Export | Experimental | Direct Kotlin-to-Swift bridge (No Obj-C) |
 | Kotlinx Coroutines | 1.11.0 | Async and Flow-based data streams |
 | Lifecycle / ViewModel | 2.11.0 | State management and lifecycle-aware components |

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ android.useAndroidX=true
 kotlin.swift-export.experimentalFeature.nowarn=true
 
 # Project Versioning
-ledger.version.name=1.6.5
-ledger.version.code=13
+ledger.version.name=1.7.0
+ledger.version.code=14
 # Enabled parallel sync for Gradle 9.4+
 org.gradle.tooling.parallel=true


### PR DESCRIPTION
## Summary

Cuts release **1.7.0** (version code 14). No source changes — this is the version bump, the changelog entry for everything merged since `v1.6.5`, and a refresh of the stale tech-stack tables.

- `gradle.properties` — `1.6.5` / `13` → `1.7.0` / `14`
- `CHANGELOG.md` — the existing `[Unreleased]` content becomes `## [1.7.0] - 2026-08-18`; `[Unreleased]` is reset to empty and the compare links updated. Added on top of the prose that was already there:
  - **Changed** — the dependency bumps (Navigation 3 runtime 1.1.6, Logback 1.6.3, constraint-only BouncyCastle 1.85.2) and the pinned GitHub Actions refresh (`dorny/paths-filter` v4, `gradle/actions/wrapper-validation` + `dependency-submission` v6, `actions/attest` v4.2.2, `github/codeql-action/upload-sarif` v4.37.6)
  - **Removed** — `PostingDao.deleteById`, replaced by `softDeleteById` / `hardDeleteById`
- `README.md` / `CLAUDE.md` — tech-stack tables were behind the version catalog: Navigation 3 runtime `1.1.5 → 1.1.6` in both, Logback `1.6.1 → 1.6.3` in the README

### Why minor rather than major

This release removes a public API (`PostingDao.deleteById`) and regenerates schema `1.json` in place, so an install from 1.6.1–1.6.5 fails Room's integrity check and must have its app data cleared. Under strict semver that is a major bump. It is cut as a minor deliberately: the DAO surface is effectively internal to the template, and the README now states that this is a showcase project to build *from* rather than an app to keep data in. The changelog carries the warning in full.

## Related issue

n/a

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Build / CI
- [x] Documentation

## Checklist

- [x] Tests pass locally (`./gradlew allTests`)
- [x] Checks pass (`./gradlew check`)
- [x] Documentation updated where relevant
- [x] Changes follow the project's architecture and conventions (see `CLAUDE.md` / `README.md`)

<sub>`./gradlew check` passed locally (BUILD SUCCESSFUL, 1104 tasks) — includes `allTests`, `apiCheck`, Kover verify, and Android lint. iOS targets are not exercised on this machine.</sub>
