### PR TITLE
build(deps): bump Compose Multiplatform to 1.12.0, Room, and Navigation 3

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,26 +11,26 @@ kover = "0.9.9"
 # Jetpack
 androidx-activity = "1.13.0"
 androidx-lifecycle = "2.11.0"
-androidx-navigation3-runtime = "1.1.6"
+androidx-navigation3-runtime = "1.1.7"
 androidx-navigation3-ui = "1.1.1"
 androidx-adaptive = "1.3.0-beta02"
-androidx-room = "3.0.1"
+androidx-room = "3.0.2"
 androidx-sqlite = "2.7.0"
 androidx-datastore = "1.2.1"
 
 # Compose
-compose-multiplatform = "1.11.1"
+compose-multiplatform = "1.12.0"
 compose-material-icons = "1.7.3"
-androidx-material3 = "1.11.0-alpha07"
+androidx-material3 = "1.12.0-alpha03"
 
 # Third-party
 koin = "4.2.2"
 koin-compiler = "1.1.0"
 kotlinx-coroutines = "1.11.0"
 kotlinx-serialization = "1.11.0"
-kotlinx-binary-compatibility-validator = "0.18.1"
+kotlinx-binary-compatibility-validator = "0.18.2"
 kermit = "2.1.0"
-slf4j = "2.0.18"
+slf4j = "2.0.19"
 slf4j-android = "2.0.17-0"
 logback = "1.6.3"
 


### PR DESCRIPTION
## What

Bumps the version catalog:

| Dependency | From | To |
|---|---|---|
| Compose Multiplatform | 1.11.1 | 1.12.0 |
| `org.jetbrains.compose.material3` | 1.11.0-alpha07 | 1.12.0-alpha03 |
| Room | 3.0.1 | 3.0.2 |
| Navigation 3 runtime | 1.1.6 | 1.1.7 |
| binary-compatibility-validator | 0.18.1 | 0.18.2 |
| slf4j | 2.0.18 | 2.0.19 |

## Why the material3 pin moves too

material3 rides its own release train — it never publishes a version matching
`compose-multiplatform` (there is no `1.11.1`, no `1.12.0`), so the catalog keeps a
separate `androidx-material3` ref.

Bumping core Compose to 1.12.0 while leaving material3 at `1.11.0-alpha07` produces a
version skew. That build is compiled against `compose.ui:1.11.0-beta03`; Gradle's
highest-wins resolution pulls core `compose.ui` up to `1.12.0` but leaves material3
itself at `1.11.0-alpha07`, so its `Modifier.Node` implementations run against a newer
attach/detach contract than they were compiled for.

The symptom is narrow and easy to misread as a test bug: every test in
`PostingEditScreenTest` — the only screen test that renders an `OutlinedTextField` —
fails **at scene dispose**, not in the test body:

```
java.lang.IllegalStateException: Must run runDetachLifecycle() once after runAttachLifecycle() and before markAsDetached()
	at androidx.compose.ui.Modifier$Node.runDetachLifecycle$ui(Modifier.kt:447)
	at androidx.compose.ui.node.NodeChain.runDetachLifecycle$ui(NodeChain.kt:380)
	...
	at androidx.compose.ui.test.SkikoComposeUiTest.closeScene(ComposeUiTest.skiko.kt:346)
```

`material3:1.12.0-alpha03` is built against Compose `1.12.0-beta01`, which resolves *up*
to the pinned `1.12.0` — the same alignment rule that made `1.11.0-alpha07` correct for
`1.11.1`. With it, every `org.jetbrains.compose.{runtime,ui,foundation,animation}`
module on the classpath lands on a single version.

`androidx-adaptive` (1.3.0-beta02) and `compose-material-icons` (1.7.3) are already the
newest on their own trains and are left alone.

## Testing

- `./gradlew clean allTests --rerun-tasks` — passes (was 18 failures across the jvm and
  Android host-test variants of `PostingEditScreenTest`)
- `./gradlew apiCheck` — passes; the public API dumps are unchanged despite the Compose
  bump regenerating the `Res` accessors, so no `apiDump` was required

No production or test source changed — the fix is entirely in the version catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012vYaye24XkZUtuuQoC8xW8
