### PR TITLE
chore(build): silence Koin build warnings and drop dead androidApp test config

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -16,21 +16,10 @@ dependencies {
     implementation(project(":feature:posting:impl"))
     implementation(project(":feature:settings:impl"))
 
-    testImplementation(project(":core:database"))
-    testImplementation(libs.kotlin.test)
-    testImplementation(libs.koin.test)
-    testImplementation(libs.androidx.test.core)
-    testImplementation(libs.junit)
-    testImplementation(libs.robolectric)
-
+    // No local unit tests here: androidApp's only tests are instrumented (src/androidTest).
     androidTestImplementation(libs.androidx.test.ext.junit)
     androidTestImplementation(libs.androidx.test.espresso.core)
     androidTestImplementation(libs.compose.ui.test.junit4)
-
-    constraints {
-        // robolectric 4.16.1 pins bcprov 1.81 (GHSA-574f-3g2m-x479, fixed in 1.84).
-        testImplementation(libs.bouncycastle.bcprov)
-    }
 }
 
 android {
@@ -77,7 +66,6 @@ android {
         }
     }
     testOptions {
-        unitTests.isIncludeAndroidResources = true
         managedDevices {
             localDevices {
                 create("aospAtd30") {

--- a/build-logic/src/main/kotlin/ledger.kotlin.multiplatform.koin.gradle.kts
+++ b/build-logic/src/main/kotlin/ledger.kotlin.multiplatform.koin.gradle.kts
@@ -26,4 +26,6 @@ kotlin {
 // assembled graph is still checked at the entry points plus by the runtime `verify()` tests.
 koinCompiler {
     logSeverity = "info"
+    // Vendor CTA pointing at Kotzilla MCP; not a diagnostic.
+    aiAssist = false
 }

--- a/core/ui/src/commonTest/kotlin/app/oreshkov/ledger/core/ui/AppTest.kt
+++ b/core/ui/src/commonTest/kotlin/app/oreshkov/ledger/core/ui/AppTest.kt
@@ -20,17 +20,53 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.polymorphic
 import kotlinx.serialization.modules.subclass
-import org.koin.compose.KoinApplication
+import org.koin.core.annotation.KoinApplication
 import org.koin.core.annotation.KoinExperimentalAPI
-import org.koin.dsl.koinConfiguration
+import org.koin.core.annotation.Module
+import org.koin.core.annotation.Single
 import org.koin.dsl.module
 import org.koin.dsl.navigation3.navigation
+import org.koin.plugin.module.dsl.koinConfiguration
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import org.koin.compose.KoinApplication as KoinApplicationScope
 
 @Serializable
 data class TestKey(val id: String = "test") : NavKey
+
+/**
+ * Annotated so the Koin compiler plugin can resolve this test's graph statically. Passing a
+ * `module { }` lambda straight to `koinConfiguration` makes the module set dynamically computed,
+ * which downgrades the entry point to runtime-only checking (KOIN-W003).
+ */
+@Module
+class AppTestModule {
+    @Single
+    fun startDestination() = StartDestination(TestKey())
+
+    @Single
+    fun getThemeMode() = GetThemeModeUseCase(FakeSettingsRepository())
+
+    @Single
+    fun savedStateConfiguration() = SavedStateConfiguration {
+        serializersModule = SerializersModule {
+            polymorphic(NavKey::class) { subclass(TestKey::class) }
+        }
+    }
+}
+
+@KoinApplication(modules = [AppTestModule::class])
+class TestApp
+
+// `navigation<T>` has no annotation equivalent, so the screen entry stays DSL — the same split
+// the feature `*NavigationModule`s use.
+@OptIn(KoinExperimentalAPI::class)
+private val testNavigationModule = module {
+    navigation<TestKey> {
+        Text("Hello from TestKey")
+    }
+}
 
 @OptIn(ExperimentalTestApi::class, KoinExperimentalAPI::class, ExperimentalCoroutinesApi::class)
 class AppTest : PlatformComposeUiTest() {
@@ -42,30 +78,10 @@ class AppTest : PlatformComposeUiTest() {
 
     @Test
     fun app_rendersStartDestination() = runComposeUiTest {
-        val startKey = TestKey()
-
         setContent {
-            KoinApplication(
-                configuration = koinConfiguration {
-                    modules(
-                        module {
-                            single { StartDestination(startKey) }
-                            single { GetThemeModeUseCase(FakeSettingsRepository()) }
-                            single {
-                                SavedStateConfiguration {
-                                    serializersModule = SerializersModule {
-                                        polymorphic(NavKey::class) {
-                                            subclass(TestKey::class)
-                                        }
-                                    }
-                                }
-                            }
-
-                            navigation<TestKey> {
-                                Text("Hello from TestKey")
-                            }
-                        }
-                    )
+            KoinApplicationScope(
+                configuration = koinConfiguration<TestApp> {
+                    modules(testNavigationModule)
                 }
             ) {
                 App()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,7 +35,6 @@ slf4j-android = "2.0.17-0"
 logback = "1.6.3"
 
 # Test
-androidx-test-core = "1.7.0"
 androidx-test-ext-junit = "1.3.0"
 androidx-test-espresso-core = "3.7.0"
 junit = "4.13.2"
@@ -107,7 +106,6 @@ kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotl
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 compose-ui-test = { module = "org.jetbrains.compose.ui:ui-test", version.ref = "compose-multiplatform" }
 compose-ui-test-junit4 = { module = "org.jetbrains.compose.ui:ui-test-junit4", version.ref = "compose-multiplatform" }
-androidx-test-core = { module = "androidx.test:core", version.ref = "androidx-test-core" }
 androidx-test-ext-junit = { module = "androidx.test.ext:junit", version.ref = "androidx-test-ext-junit" }
 androidx-test-espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "androidx-test-espresso-core" }
 junit = { module = "junit:junit", version.ref = "junit" }


### PR DESCRIPTION
## Summary

`./gradlew clean allTests --rerun-tasks` emitted 150 compiler warnings. This PR fixes the six Koin
ones — one of which turned out to be a real gap rather than noise — and removes dead test
configuration in `androidApp` that the review surfaced along the way.

Warnings drop **150 → 144**.

## KOIN-W003 was hiding a real gap

`AppTest` built its graph by passing a `module { }` lambda to `koinConfiguration`. The Koin compiler
plugin treats `koinConfiguration` as an entry point, and a lambda module set is not statically
resolvable, so it reported:

> Compile-time dependency checks are **skipped for this entry point**; it is validated at runtime via
> `checkModules()`. Pass module classes directly — e.g. `modules(MyModule::class)` — to enable full
> compile-time verification.

So the test graph was runtime-validated only. Anchoring it with an annotated `@Module` plus a
`@KoinApplication` marker type, and switching to the plugin-aware `koinConfiguration<TestApp>`
overload, restores full compile-time verification. `navigation<TestKey>` has no annotation
equivalent, so the screen entry stays in a DSL module passed through the declaration lambda — the
same split the feature `*NavigationModule`s already use.

**The three real app entry points were checked and were never affected.**
`:androidApp:compileDebugKotlin` run with `-i` emits neither KOIN-W003 nor a
`compile-safety validation skipped` notice, so `startKoin<LedgerApp> { modules(...) }` is statically
verified — `@KoinApplication(modules = [BootstrapModule::class])` anchors it.

## `aiAssist = false`

The plugin emits a Kotzilla MCP advertisement at WARNING severity whenever any Koin diagnostic
fires. It is a vendor CTA, not a diagnostic, and would fail a future `allWarningsAsErrors` build.

## Dead `androidApp` test configuration

`androidApp/src` has no `src/test` — only instrumented `src/androidTest` — so
`:androidApp:testDebugUnitTest` is `NO-SOURCE`. Removed six `testImplementation` deps, the bcprov
`constraints` block, and `unitTests.isIncludeAndroidResources`. That leaves `androidx-test-core`
unreferenced anywhere, so its two catalog entries go too.

**This is not a security change.** The bcprov constraint guards a CVE (GHSA-574f-3g2m-x479)
reachable through robolectric. Robolectric is genuinely used by `core:test`
(`PlatformComposeUiTest.android.kt`), which carries its own identical constraint. Only the duplicate
in `androidApp` is removed.

`testOptions.managedDevices` is deliberately **kept** — CI runs
`:androidApp:aospAtd30DebugAndroidTest` (`.github/workflows/build.yml`).

## Verification

- `./gradlew check :androidApp:assembleDebugAndroidTest` — **BUILD SUCCESSFUL**, including
  `apiCheck`, `koverVerify` and `lint` on every module.
- `./gradlew clean allTests --rerun-tasks` — 144 warnings (from 150), 72 test XMLs.
- `AppTest` passes on `jvmTest` and `testAndroidHostTest` (`tests="1" failures="0"`).
- No `apiDump` needed — the `AppTest` change is confined to `commonTest`, which BCV does not track.

## Not in scope

The remaining 144 warnings are Room KSP and Compose resource-generator output tripping
`extraWarnings`, in generated files no `@file:Suppress` can be added to. Fixing them needs a
per-module `-Xwarning-level` decision that trades the check away on hand-written code in
`core:database` and `core:compose` — kept separate deliberately.

The build also emits four Gradle "Project object as a dependency notation" deprecations. All four
originate inside AGP 9.1.1 (`VariantDependenciesBuilder`, `createForKotlinMultiplatform`); no
project build-script frames are involved. Nothing to fix here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012vYaye24XkZUtuuQoC8xW8
