### PR TITLE
chore: silence version-currency lint warnings on the AGP and Kotlin pins

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,3 +44,13 @@ updates:
       # when deliberately upgrading compose-multiplatform. Note: ignore also
       # suppresses security updates for these artifacts.
       - dependency-name: "org.jetbrains.compose.material3:*"
+      # AGP and Kotlin are pinned to what the bundled IntelliJ IDEA plugin
+      # supports (see the pins in gradle/libs.versions.toml, where the matching
+      # lint currency checks are suppressed too); bumping either breaks project
+      # import in the IDE. Drop these once IDEA supports a newer line. Note:
+      # ignore also suppresses security updates for these artifacts.
+      - dependency-name: "com.android.tools.build:gradle"
+      - dependency-name: "com.android.application:*"
+      - dependency-name: "com.android.kotlin.multiplatform.library:*"
+      - dependency-name: "org.jetbrains.kotlin:*"
+      - dependency-name: "org.jetbrains.kotlin.*:*"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,9 +1,15 @@
 [versions]
 # Build tools
+# Pinned to the AGP version the bundled IntelliJ IDEA plugin supports; bumping to
+# the latest stable breaks project import in the IDE. Suppressed on this line
+# only, so every other dependency is still checked for currency.
+#noinspection AndroidGradlePluginVersion
 android-gradle-plugin = "9.1.1"
 android-sdk-compile = "37"
 android-sdk-min = "24"
 android-sdk-target = "37"
+# Pinned for the same IntelliJ IDEA compatibility reason as the AGP version above.
+#noinspection GradleDependency,NewerVersionAvailable
 kotlin = "2.4.0"
 ksp = "2.3.9"
 kover = "0.9.9"


### PR DESCRIPTION
Android lint reported 9 warnings, every one of them pointing at the two versions that are
deliberately pinned to what the bundled IntelliJ IDEA plugin supports:
`AndroidGradlePluginVersion` on the AGP entry, and `GradleDependency` +
`NewerVersionAvailable` on the Kotlin entry. Bumping either breaks project import in the IDE,
so the warnings can never be actioned — they are permanent noise that hides real findings.

## Approach

Line-scoped `#noinspection` comments in `gradle/libs.versions.toml`, directly above the two
pinned entries, each with a comment explaining why the pin exists.

Two alternatives were rejected:

- **Project-wide `lint { disable }`** — switches the currency checks off for every dependency,
  not just the two that are pinned on purpose. The whole point is to keep getting currency
  warnings for everything else.
- **A lint baseline** — baseline entries match on message text, and these messages embed the
  available version (`"is available: 9.4.0"`). The next AGP release changes the message and the
  warnings come straight back, so the baseline would need re-generating on every upstream
  release.

`.github/dependabot.yml` gets matching ignore rules for the same artifacts. Without them
Dependabot keeps opening exactly the bumps lint is now being told to ignore, which just moves
the noise from the lint report to the PR queue. Both the catalog comments and the Dependabot
comments state the condition for removal: drop them once IDEA supports a newer line. Note that
`ignore` also suppresses security updates for those artifacts.

## Changes

| File | Change |
|---|---|
| `gradle/libs.versions.toml` | `#noinspection` on the AGP and Kotlin pins, with rationale comments |
| `.github/dependabot.yml` | ignore rules for `com.android.tools.build:gradle`, the AGP plugin ids, and `org.jetbrains.kotlin*` |

## Verification

`./gradlew :androidApp:lintDebug --rerun-tasks` reports `No issues found`, down from
`0 errors, 9 warnings`. Re-verified on this branch after rebasing onto current `main`.

`--rerun-tasks` is not optional here: lint tasks go `UP-TO-DATE` after a version-catalog edit,
so an ordinary run replays a stale report and makes an ineffective suppression look like it
worked.

`./gradlew check` passes.
