### PR TITLE
chore(desktop): add Compose Hot Reload with the MCP server

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "compose-hot-reload": {
+      "command": "./gradlew",
+      "args": [
+        "--no-daemon",
+        "--quiet",
+        "--console=plain",
+        ":desktopApp:hotMcpServer"
+      ]
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 # Run Desktop (JVM) application
 ./gradlew :desktopApp:run
 
+# Run Desktop with hot reload (JetBrains Runtime is provisioned on first use);
+# :desktopApp:hotMcpServer exposes the same session to MCP clients (see .mcp.json)
+./gradlew :desktopApp:hotRun
+
 # iOS: open iosApp/iosApp.xcodeproj in Xcode
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,21 @@ JDK 21+ is required. Useful commands:
 ./gradlew check        # full gate: tests + API check + lint + coverage floors
 ```
 
+## Running the desktop app with hot reload
+
+```bash
+./gradlew :desktopApp:hotRun
+```
+
+Code edits are applied to the running window without a restart. The first run downloads a
+JetBrains Runtime (hot reload needs its enhanced class redefinition) and caches it outside
+the project; normal builds are unaffected and keep using the daemon JDK.
+
+The same plugin exposes `:desktopApp:hotMcpServer`, an MCP endpoint that lets a coding
+agent reload, screenshot, read the semantic tree and drive the running app. `.mcp.json`
+wires it up for MCP clients that read that file. It invokes `./gradlew`, so on Windows
+register the server with the `gradlew.bat` form locally instead.
+
 ## Pull request expectations
 
 - **CI must pass** — the `CI Success` status check gates merges. It runs `check`,

--- a/README.md
+++ b/README.md
@@ -411,6 +411,16 @@ A separate `instrumented-tests` job runs the Android smoke suite on a **Gradle M
 ./gradlew :desktopApp:run
 ```
 
+### Run on Desktop with hot reload
+
+```bash
+./gradlew :desktopApp:hotRun
+```
+
+Edits to composable code are applied to the running window without a restart. Hot reload
+runs on a JetBrains Runtime, which the plugin downloads and caches on first use, so no
+local JBR install is required.
+
 ### Run on iOS
 
 1.  Open `iosApp/iosApp.xcodeproj` in Xcode.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     alias(libs.plugins.android.library.multiplatform) apply false
     alias(libs.plugins.kotlin.compose.compiler) apply false
     alias(libs.plugins.jetbrains.compose) apply false
+    alias(libs.plugins.compose.hot.reload) apply false
     alias(libs.plugins.kotlin.multiplatform) apply false
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.kotlin.jvm) apply false

--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     alias(libs.plugins.jetbrains.compose)
     alias(libs.plugins.kotlin.compose.compiler)
     alias(libs.plugins.koin.compiler)
+    alias(libs.plugins.compose.hot.reload)
 }
 
 dependencies {

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,6 +13,13 @@ org.gradle.parallel=true
 android.nonTransitiveRClass=true
 android.useAndroidX=true
 
+# Compose Hot Reload: let the plugin download a JetBrains Runtime for the hot-run JVM
+# only. JBR ships the enhanced class redefinition hot reload needs, and the plugin caches
+# it under <GRADLE_USER_HOME>/chr/jbr rather than going through Gradle toolchain
+# resolution, so compilation keeps using the daemon JDK from
+# gradle/gradle-daemon-jvm.properties and no toolchain resolver plugin is required.
+compose.reload.jbr.autoProvisioningEnabled=true
+
 # Kotlin Experimental
 kotlin.swift-export.experimentalFeature.nowarn=true
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,9 @@ android-sdk-target = "37"
 kotlin = "2.4.0"
 ksp = "2.3.9"
 kover = "0.9.9"
+# Bundled with Compose Multiplatform 1.12.0; drives :desktopApp:hotRun and the
+# hotMcpServer endpoint. Runs on a JetBrains Runtime the plugin provisions itself.
+compose-hot-reload = "1.2.0"
 
 # Jetpack
 androidx-activity = "1.13.0"
@@ -126,6 +129,7 @@ common-test = ["kotlin-test", "kotlinx-coroutines-test"]
 android-application = { id = "com.android.application", version.ref = "android-gradle-plugin" }
 android-library-multiplatform = { id = "com.android.kotlin.multiplatform.library", version.ref = "android-gradle-plugin" }
 jetbrains-compose = { id = "org.jetbrains.compose", version.ref = "compose-multiplatform" }
+compose-hot-reload = { id = "org.jetbrains.compose.hot-reload", version.ref = "compose-hot-reload" }
 kotlin-compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }


### PR DESCRIPTION
Compose Multiplatform 1.12.0 bundles Compose Hot Reload 1.2.0, whose headline addition is an
MCP server. This wires both into `desktopApp`.

## What this adds

- `./gradlew :desktopApp:hotRun` — edits to composable code are applied to the running window
  without a restart (`hotRunAsync` for the non-blocking form).
- `./gradlew :desktopApp:hotMcpServer` — an MCP endpoint exposing `reload`, `take_screenshot`,
  `get_semantic_tree`, `get_logs`, `click`, `type_text` and `scroll` against the running app.
  `.mcp.json` wires it up for MCP clients that read that file.

The second one is the reason for the change: UI verification currently stops at
`runDesktopComposeUiTest`, which asserts on the semantics tree but never renders. The MCP
endpoint closes that loop — a change can be reloaded, screenshotted and clicked through
against the real window.

## Changes

| File | Change |
|---|---|
| `gradle/libs.versions.toml` | `compose-hot-reload = "1.2.0"` + the plugin alias |
| `build.gradle.kts` | register the plugin, `apply false` |
| `desktopApp/build.gradle.kts` | apply it |
| `gradle.properties` | `compose.reload.jbr.autoProvisioningEnabled=true` |
| `.mcp.json` | new — points an MCP client at `:desktopApp:hotMcpServer` |
| `README.md`, `CONTRIBUTING.md`, `CLAUDE.md` | document `hotRun` and the MCP task |

## On the JetBrains Runtime

Hot reload needs JBR's enhanced class redefinition, and the JVM running the app must be a JBR
even though compilation stays on the daemon JDK.

The upstream docs offer two routes: the `org.gradle.toolchains.foojay-resolver-convention`
settings plugin, or the `compose.reload.jbr.autoProvisioningEnabled` property. This PR uses
only the property. The foojay plugin was tried first and measurably did nothing here — with it
applied, `./gradlew javaToolchains` still reported `Auto-download: Disabled` and listed no
JetBrains Runtime, because the hot-reload plugin does its own provisioning into
`<GRADLE_USER_HOME>/chr/jbr` rather than requesting a Gradle toolchain. Adding a settings
plugin that resolves nothing is supply-chain surface for no benefit, so it was dropped.

## Verification

- `./gradlew :desktopApp:tasks --all` lists `hotRun`, `hotRunAsync` and `hotMcpServer` (the
  plain Kotlin/JVM task names — the `hotRunJvm` form is for multiplatform modules).
- `./gradlew :desktopApp:hotRunAsync` launches the app; the process runs on a
  freshly-provisioned JBR (`chr/jbr/jbrsdk_jcef-25.0.2-windows-x64-b329.72/bin/java.exe`),
  confirmed by process path — verified again after the foojay plugin was removed.
- `./gradlew check` passes; the configuration cache still stores and reuses entries.
- No public API change, so no `apiDump` is needed.

## Notes

- `.mcp.json` invokes `./gradlew`. That is the documented, POSIX form; on Windows the server
  has to be registered locally with the `gradlew.bat` form instead. Noted in `CONTRIBUTING.md`.
- The plugin puts a small `hot-reload-annotations` artifact on the desktop runtime classpath,
  so it will show up in the dependency graph. `dependency-submission.yml` needs no change —
  its allowlist is already runtime-only.
- Hot reload is a development affordance only; `:desktopApp:run` and the packaged
  distributions are untouched.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NMrZNkAH1Mw4cMZV65Co16
