### PR TITLE
fix(desktop): express the window minimum size in Dp via the v2 window API

### DIFF
--- a/desktopApp/api/desktopApp.api
+++ b/desktopApp/api/desktopApp.api
@@ -1,7 +1,7 @@
 public final class app/oreshkov/ledger/ComposableSingletons$MainKt {
 	public static final field INSTANCE Lapp/oreshkov/ledger/ComposableSingletons$MainKt;
 	public fun <init> ()V
-	public final fun getLambda$452509557$Ledger_desktopApp ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$18003959$Ledger_desktopApp ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda$574834339$Ledger_desktopApp ()Lkotlin/jvm/functions/Function3;
 }
 

--- a/desktopApp/src/main/kotlin/app/oreshkov/ledger/main.kt
+++ b/desktopApp/src/main/kotlin/app/oreshkov/ledger/main.kt
@@ -1,9 +1,14 @@
 package app.oreshkov.ledger
 
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
-import androidx.compose.ui.window.rememberWindowState
+import androidx.compose.ui.window.v2.Window
+import androidx.compose.ui.window.v2.WindowBoundsProvider
+import androidx.compose.ui.window.v2.WindowPositionProvider
+import androidx.compose.ui.window.v2.WindowSizeProvider
+import androidx.compose.ui.window.v2.rememberWindowState
 import app.oreshkov.ledger.core.bootstrap.di.BootstrapModule
 import app.oreshkov.ledger.core.ui.App
 import app.oreshkov.ledger.feature.posting.impl.di.postingNavigationModule
@@ -11,22 +16,34 @@ import app.oreshkov.ledger.feature.settings.impl.di.settingsNavigationModule
 import org.koin.core.annotation.KoinApplication
 import org.koin.plugin.module.dsl.startKoin
 
-import java.awt.Dimension
-
 @KoinApplication(modules = [BootstrapModule::class])
 class LedgerApp
 
+// Window API v2 (Compose Multiplatform 1.12.0). Experimental, and its KDoc notes the package
+// may move to androidx.compose.ui.window before stabilization — expect an import change, not a
+// rewrite. It is used here because `minSize` is typed in Dp: the v1 form had to reach through
+// to AWT (`window.minimumSize = Dimension(350, 600)`), whose device pixels do not scale with
+// display density, so the floor was half the intended physical size at 200% while the Dp-typed
+// initial size scaled correctly.
+@OptIn(ExperimentalComposeUiApi::class)
 fun main() {
     startKoin<LedgerApp> {
         modules(postingNavigationModule, settingsNavigationModule)
     }
     application {
         Window(
-            title = "Ledger",
-            state = rememberWindowState(width = 800.dp, height = 600.dp),
             onCloseRequest = ::exitApplication,
+            title = "Ledger",
+            state = rememberWindowState(
+                initialBoundsProvider = WindowBoundsProvider(
+                    sizeProvider = WindowSizeProvider.Fixed(DpSize(800.dp, 600.dp)),
+                    // The v1 default cascades new windows from the last position, which on a
+                    // multi-monitor setup lands wherever the previous window was.
+                    positionProvider = WindowPositionProvider.CenteredOnScreen,
+                ),
+            ),
+            minSize = DpSize(350.dp, 600.dp),
         ) {
-            window.minimumSize = Dimension(350, 600)
             App()
         }
     }


### PR DESCRIPTION
The desktop window's minimum size was expressed in raw device pixels while its initial size was
expressed in Dp, so the two disagreed on any display that isn't at 100% scaling.

```kotlin
state = rememberWindowState(width = 800.dp, height = 600.dp),  // density-scaled
) {
    window.minimumSize = Dimension(350, 600)                   // device pixels, not scaled
```

At 200% scaling the initial window is 1600×1200 physical pixels while the floor stays 350×600
physical — half the intended size — so the window can be dragged far smaller than the layout is
built for. At 100% the two happen to agree, which is why it went unnoticed. It also reached
through Compose into AWT from inside the window's content lambda, re-applying the minimum on
every recomposition.

Compose Multiplatform 1.12.0 adds `androidx.compose.ui.window.v2`, where `minSize` is typed in
`Dp` and the AWT escape hatch is no longer needed:

```kotlin
Window(
    onCloseRequest = ::exitApplication,
    title = "Ledger",
    state = rememberWindowState(
        initialBoundsProvider = WindowBoundsProvider(
            sizeProvider = WindowSizeProvider.Fixed(DpSize(800.dp, 600.dp)),
            positionProvider = WindowPositionProvider.CenteredOnScreen,
        ),
    ),
    minSize = DpSize(350.dp, 600.dp),
) {
    App()
}
```

`CenteredOnScreen` is a second, smaller fix: the v1 default cascades each new window from the
last one's position, which on a multi-monitor setup opens the app wherever the previous window
happened to be.

## Stability

The v2 API is `@ExperimentalComposeUiApi`, and its KDoc says the package "may be moved to
`androidx.compose.ui.window` before stabilization" — so the expected future cost is an import
change, not a rewrite. It is opt-in per call site and confined to `main.kt`. A comment on the
function records both the reason for the opt-in and the pixel/Dp bug it fixes, so the next
reader doesn't undo it.

## Verification

Measured against the running app rather than assumed:

- Launched via `:desktopApp:hotRunAsync`; the window opens at 800×600 at `(454, 210)` on a
  1707×1019 work area — centred to the pixel, confirming `CenteredOnScreen`.
- Forcing a resize below the floor with `SetWindowPos(..., 200, 300, ...)` clamps to exactly
  350×600, confirming `minSize` is enforced.
- `./gradlew check` passes.
- `./gradlew apiDump` regenerated `desktopApp/api/desktopApp.api`. The only change is a Compose
  synthetic lambda key (`getLambda$452509557$` → `getLambda$18003959$`) that shifts whenever the
  composable content changes; no real API moved.

Note the verification machine runs at 100% scaling, so it confirms the new code is correct but
cannot itself demonstrate the 200% failure the change fixes; that part rests on the unit
mismatch being plain in the old code.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NMrZNkAH1Mw4cMZV65Co16
