### PR TITLE
docs: refresh the version tables and record why Material3 is pinned to an alpha

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,13 +96,15 @@ Three composable Gradle plugins — modules declare one of these instead of conf
 | Technology | Version |
 |---|---|
 | Kotlin | 2.4.0 |
-| Compose Multiplatform | 1.11.1 |
+| Compose Multiplatform | 1.12.0 |
 | Koin | 4.2.2 |
-| Room | 3.0.1 |
-| Navigation 3 | 1.1.6 (runtime) / 1.1.1 (ui) |
+| Room | 3.0.2 |
+| Navigation 3 | 1.1.7 (runtime) / 1.1.1 (ui) |
 | AndroidX DataStore | 1.2.1 |
 | Coroutines | 1.11.0 |
 | Kover | 0.9.9 |
+
+Material3 and Material3 Adaptive are pinned to prerelease versions (`androidx-material3 = "1.12.0-alpha03"`, `androidx-adaptive = "1.3.0-beta02"`) on purpose: those are the exact coordinates Compose Multiplatform 1.12.0 declares itself aligned to. They are not debt to pay down, and moving either to a "stable" number would de-align the stack. Re-check the alignment table in the Compose Multiplatform release notes on every CM bump.
 
 ## Module Conventions
 

--- a/README.md
+++ b/README.md
@@ -61,20 +61,20 @@ study in this repo (`.claude/`, `.github/workflows/`) — pre-wired to your proj
 |---|---|---|
 | Kotlin | 2.4.0 | Language and compiler |
 | Kotlin Gradle Plugin | 2.4.0 | Build tooling |
-| Compose Multiplatform | 1.11.1 | Shared UI (Android, iOS, Desktop) |
-| Room 3 / SQLite | 3.0.1 / 2.7.0 | Local database with KMP support |
+| Compose Multiplatform | 1.12.0 | Shared UI (Android, iOS, Desktop) |
+| Room 3 / SQLite | 3.0.2 / 2.7.0 | Local database with KMP support |
 | AndroidX DataStore (Preferences) | 1.2.1 | Multiplatform key-value persistence (theme preference) |
-| Navigation 3 | 1.1.6 (runtime) / 1.1.1 (ui) | Type-safe declarative navigation |
-| Material3 Adaptive Navigation Suite | 1.11.0-alpha07 | Adaptive top-level nav (bottom bar / rail / drawer) |
+| Navigation 3 | 1.1.7 (runtime) / 1.1.1 (ui) | Type-safe declarative navigation |
+| Material3 Adaptive Navigation Suite | 1.12.0-alpha03 | Adaptive top-level nav (bottom bar / rail / drawer) |
 | Koin | 4.2.2 | Dependency injection with annotation processing |
 | Kermit | 2.1.0 | Kotlin Multiplatform logging |
 | Kover | 0.9.9 | Kotlin Multiplatform code coverage |
-| SLF4J / Logback | 2.0.18 / 1.6.3 | Desktop logging implementation |
+| SLF4J / Logback | 2.0.19 / 1.6.3 | Desktop logging implementation |
 | Swift Export | Experimental | Direct Kotlin-to-Swift bridge (No Obj-C) |
 | Kotlinx Coroutines | 1.11.0 | Async and Flow-based data streams |
 | Lifecycle / ViewModel | 2.11.0 | State management and lifecycle-aware components |
 | Material3 Adaptive | 1.3.0-beta02 | List/detail adaptive layouts |
-| Material3 (Compose) | 1.11.0-alpha07 | Material You components |
+| Material3 (Compose) | 1.12.0-alpha03 | Material You components |
 | Android SDK | compile/target 37, min 24 | Android target |
 
 ---

--- a/feature/settings/impl/src/commonTest/kotlin/app/oreshkov/ledger/feature/settings/impl/SettingsScreenTest.kt
+++ b/feature/settings/impl/src/commonTest/kotlin/app/oreshkov/ledger/feature/settings/impl/SettingsScreenTest.kt
@@ -103,7 +103,6 @@ class SettingsScreenTest : PlatformComposeUiTest() {
         onNodeWithTag("theme_dark").assertIsSelected()
 
         onNodeWithTag("theme_light").performClick()
-        waitForIdle()
 
         onNodeWithTag("theme_light").assertIsSelected()
     }
@@ -118,7 +117,6 @@ class SettingsScreenTest : PlatformComposeUiTest() {
         }
 
         onNodeWithTag("theme_dark").performClick()
-        waitForIdle()
 
         onNodeWithText("Failed to save. Please try again.").assertIsDisplayed()
     }


### PR DESCRIPTION
Documentation drift left behind by the Compose Multiplatform 1.12.0 bump (#20) and the Room and
Navigation 3 bumps that rode along with it, plus one test cleanup that the same release enables.

## Version tables

`CLAUDE.md` and `README.md` both list library versions that no longer match
`gradle/libs.versions.toml`. Every value below was re-read from the catalog rather than assumed:

| Entry | Was | Now |
|---|---|---|
| Compose Multiplatform | 1.11.1 | 1.12.0 |
| Room (README: Room 3 / SQLite) | 3.0.1 | 3.0.2 |
| Navigation 3 runtime | 1.1.6 | 1.1.7 |
| Material3 (Compose) | 1.11.0-alpha07 | 1.12.0-alpha03 |
| Material3 Adaptive Navigation Suite | 1.11.0-alpha07 | 1.12.0-alpha03 |
| SLF4J | 2.0.18 | 2.0.19 |

Entries that were already correct (Kotlin 2.4.0, Koin 4.2.2, DataStore 1.2.1, Coroutines 1.11.0,
Kover 0.9.9, Kermit 2.1.0, Lifecycle 2.11.0, Material3 Adaptive 1.3.0-beta02, Android SDK
37/24) are untouched.

## Why the Material3 alphas are deliberate

`CLAUDE.md` gains a short note recording that `androidx-material3 = "1.12.0-alpha03"` and
`androidx-adaptive = "1.3.0-beta02"` are the exact coordinates Compose Multiplatform 1.12.0
declares itself aligned to. Without that written down, a currency review reasonably reads two
prerelease pins as debt and "fixes" them to a stable number, which would de-align the stack
from the CM release. The note also says to re-check the alignment table on every CM bump.

## Redundant `waitForIdle()`

`SettingsScreenTest` called `waitForIdle()` after `performClick()` in two tests. Under the v2
test API the standard node queries (`onNodeWithTag`, `fetchSemanticsNode`, …) already trigger a
`waitForIdle()` internally — stated explicitly in the 1.12.0 KDoc for the new
`ComposeUiTest.runWithoutImplicitWait` — so the explicit calls do nothing. Removed.

The `waitUntilExactlyOneExists` in `PostingEditScreenTest` is a real wait for a snackbar and is
left alone.

## Verification

- `./gradlew :feature:settings:impl:allTests --rerun-tasks` — `SettingsScreenTest` runs 6 tests
  on both `jvmTest` and `testAndroidHostTest`, 0 skipped, 0 failures. `--rerun-tasks` so the
  result is not a replayed cache entry.
- `./gradlew check` passes.

No code or public API changes, so no `apiDump`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NMrZNkAH1Mw4cMZV65Co16
