### PR TITLE
fix(mcp): launch the hot-reload MCP server through the wrapper JAR

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,11 @@
 {
   "mcpServers": {
     "compose-hot-reload": {
-      "command": "./gradlew",
+      "command": "java",
       "args": [
+        "-classpath",
+        "gradle/wrapper/gradle-wrapper.jar",
+        "org.gradle.wrapper.GradleWrapperMain",
         "--no-daemon",
         "--quiet",
         "--console=plain",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `.mcp.json` now launches the `:desktopApp:hotMcpServer` endpoint through the Gradle wrapper JAR (`java -classpath gradle/wrapper/gradle-wrapper.jar org.gradle.wrapper.GradleWrapperMain`) instead of `./gradlew`. MCP clients spawn the command without a shell, so the extensionless POSIX `gradlew` script could not be executed on Windows and the server failed to start; the wrapper JAR is the same entry point the scripts themselves exec and works unchanged on all three host platforms, needing only `java` on `PATH`. Windows contributors no longer have to register a `gradlew.bat` server locally, as 1.8.0 required.
+
 ## [1.8.0] - 2026-09-05
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,9 +32,15 @@ JetBrains Runtime (hot reload needs its enhanced class redefinition) and caches 
 the project; normal builds are unaffected and keep using the daemon JDK.
 
 The same plugin exposes `:desktopApp:hotMcpServer`, an MCP endpoint that lets a coding
-agent reload, screenshot, read the semantic tree and drive the running app. `.mcp.json`
-wires it up for MCP clients that read that file. It invokes `./gradlew`, so on Windows
-register the server with the `gradlew.bat` form locally instead.
+agent reload, screenshot, read the semantic tree and drive the running app. It attaches to
+an app that is already running, so start one with `:desktopApp:hotRunAsync` first.
+
+`.mcp.json` wires the endpoint up for MCP clients that read that file. It starts the
+wrapper the way the `gradlew` scripts do internally — `java -classpath
+gradle/wrapper/gradle-wrapper.jar org.gradle.wrapper.GradleWrapperMain` — rather than
+running `./gradlew`. MCP clients spawn the command without a shell, and `gradlew` is an
+extensionless POSIX script that Windows cannot execute; the wrapper JAR is identical on
+every platform and needs only `java` on `PATH`.
 
 ## Pull request expectations
 


### PR DESCRIPTION
## Problem

MCP clients spawn the configured command **directly, without a shell**. `.mcp.json` pointed at `./gradlew`, which is an extensionless POSIX script — Windows cannot execute it, so the `:desktopApp:hotMcpServer` endpoint never started. Windows contributors had to register a `gradlew.bat` server locally, as documented for 1.8.0.

## Fix

Invoke the entry point the `gradlew` scripts exec internally:

```
java -classpath gradle/wrapper/gradle-wrapper.jar org.gradle.wrapper.GradleWrapperMain
```

The wrapper JAR is byte-identical on every host and needs only `java` on `PATH`, so the same `.mcp.json` now works unchanged on macOS, Linux and Windows.

## Also

`CONTRIBUTING.md` now states that the endpoint **attaches to an already-running app**, so `:desktopApp:hotRunAsync` has to be started first — that was previously unstated and is an easy way to think the server is broken.

## Verification

Not covered by an automated test — `.mcp.json` is client configuration, not built code. Worth a manual check that the MCP server starts from your client on Windows before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CnPG14rT7b66gYbsSCprEi