### PR TITLE
chore(claude): make the review agents derive versions and enforce read-only

### DIFF
--- a/.claude/REVIEW-CONVENTIONS.md
+++ b/.claude/REVIEW-CONVENTIONS.md
@@ -6,7 +6,12 @@ subagents from `.claude/agents/` in parallel waves and merge their findings into
 prioritized review **document**. The skills' sole output is that document — a dated
 markdown file under `docs/` (see *Synthesize* below); they make **no other changes**
 to source, build, test, or config files (each subagent may persist notes to its own
-project memory). `review-house` is the project-rules lens, `review-currency` the
+project memory). That read-only posture is **enforced, not just asked for**: every
+`rv-*`/`bp-*` agent carries a `PreToolUse` hook
+(`.claude/hooks/guard-agent-memory-writes.sh`) that blocks any `Write`/`Edit` outside
+`.claude/agent-memory/`. If a specialist reports being blocked, it tried to edit
+something it shouldn't — record the proposed change as a finding.
+`review-house` is the project-rules lens, `review-currency` the
 upstream-currency lens, `review-all` runs both; see `.claude/agents/README.md` for the
 full agent roster and ownership matrix.
 
@@ -29,11 +34,22 @@ wording). The shared shape: report only real gaps; give **severity** (Critical /
 Should-fix / Optional), **`file:line`**, and a **concrete fix**; respect deliberate
 pinned project decisions; do not invent findings when an area is sound.
 
+## Handle partial specialist output
+A subagent that hits its `maxTurns` limit returns output the harness marks **partial**.
+Treat a partial return as *partially reviewed*, never as *clean*: name the sub-areas the
+specialist did not reach in the review document, under the specialist's own findings.
+Silence from a truncated agent is absence of evidence, not evidence of health. If a
+domain came back badly truncated, say so in the health summary and offer to re-run that
+one specialist.
+
 ## Synthesize — write the review document
 Merge all specialist reports into a single markdown document and **write it to**
-`docs/<lens>-review-YYYY-MM-DD.md`, using the review date and the lens prefix:
-`full-review-` for `/review-all`, `house-review-` for `/review-house`,
-`currency-review-` for `/review-currency`. Writing this one file **is** the skill's
+`docs/<today>-<lens>-review.md` — the date the skill injected, then the lens:
+`<today>-full-review.md` for `/review-all`, `<today>-house-review.md` for
+`/review-house`, `<today>-currency-review.md` for `/review-currency`. The
+**date-first** shape is the repo's `docs/` convention (`YYYY-MM-DD-<topic>.md`), so the
+directory sorts chronologically; older reviews use a legacy `<lens>-review-<date>.md`
+name — do not follow them. Writing this one file **is** the skill's
 deliverable — it is not a "code change"; do not edit any source, build, test, or config
 file. If a doc with that name already exists (a re-run on the same day), overwrite it.
 

--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -11,7 +11,35 @@ agent is invoked.
 | **Currency** (`bp-*`) | `agents/currency/` | `+ WebSearch, WebFetch` | *"Do the code and our rules still match the latest official upstream guidance?"* | `/review-currency` |
 
 All agents share the same posture: **read-only review** (they propose fixes, make no
-code edits), `model: opus`, `memory: project`, `maxTurns: 40`, `effort: high`.
+code edits), `model: opus`, `memory: project`, `maxTurns: 40`, `effort: high`,
+`experimental.cacheTtl: 1h`.
+
+## Two standing rules for this family
+
+**1. Read-only is enforced, not asked for.** `memory: project` makes the harness grant
+`Write`/`Edit` even though `tools:` omits them — otherwise the agent could not persist
+memory. So every agent carries a `PreToolUse` hook, matcher `"Write|Edit"`, running
+`.claude/hooks/guard-agent-memory-writes.sh`: a write under `.claude/agent-memory/`
+passes, anything else is blocked (exit 2) with a reason telling the agent to report the
+change as a finding instead. The hook lives in **agent frontmatter, not
+`settings.json`**, so it is active only while a review subagent runs and never
+constrains the main session. Agent-level hooks require trusting the folder containing
+the agent file. Do **not** "simplify" this to `disallowedTools: Write, Edit` — that
+would break `memory: project`.
+
+**2. Never hardcode what you can read from the repo.** An agent prompt must not assert a
+library version, a module name, or a target list. It names the *source* —
+`gradle/libs.versions.toml`, `gradle/wrapper/gradle-wrapper.properties`, `build-logic/`
+— and instructs the agent to read it. Copies of these facts rot silently: an audit on
+2026-09-06 found `bp-compose`, `bp-room` and `bp-testing` measuring the code against
+version pins that were ten weeks out of date, while `bp-gradle` and `bp-android` — the
+two that derived their versions — were still correct.
+
+The `bp-*` family also shares one reporting contract, factored into the
+`currency-findings-contract` skill and preloaded via each agent's `skills:` frontmatter
+rather than copy-pasted into nine bodies. Each `bp-*` body keeps only its own
+domain-specific *deliberate choices* line. The `rv-*` reporting rules are genuinely
+per-domain and stay inline.
 
 ## Pairing / ownership matrix
 
@@ -26,7 +54,7 @@ defers the internal-correctness call to its review pair.
 | Kotlin + coroutines | `rv-concurrency` | `bp-kotlin` | purple |
 | KMP structure / Swift export | `rv-kmp` | `bp-kmp` | pink |
 | Compose + Navigation 3 | `rv-compose` | `bp-compose` | green |
-| Room / data layer | `rv-data` | `bp-room` | cyan |
+| Room / DataStore / data layer | `rv-data` | `bp-room` | cyan |
 | Koin / DI | `rv-di` | `bp-koin` | orange |
 | Gradle / build | `rv-build` | `bp-gradle` | blue |
 | CI / supply chain | `rv-ci` | `bp-ci` | red |
@@ -62,6 +90,14 @@ Each agent has `memory: project`, stored at `.claude/agent-memory/<name>/` (keye
 ## Adding or renaming an agent
 1. Put the file in the right family folder; set a unique `name` (the identity).
 2. Add it to this matrix and to the orchestrating skill's specialist list
-   (`/review-house` or `/review-currency`).
+   (`/review-house` or `/review-currency`), **and** to `/review-all`'s roster.
 3. If it has a pair, give both the same color and note the lane boundary here rather
-   than restating it in each agent body.
+   than restating it in each agent body. Check the pair reference in **both** bodies —
+   a stale one (`bp-ci` pointed at `rv-build` for ten weeks) silently breaks the
+   cross-lens de-duplication rule.
+4. Copy the shared frontmatter block (`model`, `memory`, `maxTurns`, `effort`,
+   `experimental`, `hooks`) from a sibling; for a `bp-*` agent also add
+   `skills: [currency-findings-contract]`.
+5. Keep the `description` short — it loads at every session start, while the body
+   loads only when the agent runs. Target the ~220–260 char band the existing agents
+   sit in, and put sources, checklists and boundaries in the body.

--- a/.claude/agents/currency/bp-android.md
+++ b/.claude/agents/currency/bp-android.md
@@ -1,12 +1,22 @@
 ---
 name: bp-android
-description: Senior Android platform engineer who audits the Android app target against the latest official Android platform best practices as of the review date — manifest, targetSdk/compileSdk currency, privacy/permissions, data backup, predictive back, edge-to-edge. Fetches developer.android.com for current guidance, cites every finding, makes no code edits; persists notes to its project memory.
+description: Senior Android platform engineer. Currency lens: audits the Android target — targetSdk/compileSdk, manifest, permissions, backup, predictive back, edge-to-edge — against the latest official Android guidance. Review-only — makes no code edits.
 tools: Read, Grep, Glob, Bash, WebSearch, WebFetch
+skills:
+  - currency-findings-contract
 model: opus
 memory: project
 color: yellow
 maxTurns: 40
 effort: high
+experimental:
+  cacheTtl: 1h
+hooks:
+  PreToolUse:
+    - matcher: "Write|Edit"
+      hooks:
+        - type: command
+          command: "${CLAUDE_PROJECT_DIR}/.claude/hooks/guard-agent-memory-writes.sh"
 ---
 
 You are a senior Android platform engineer. Your job is currency: does the
@@ -58,7 +68,8 @@ threat-model framing to `rv-security`. Full ownership matrix:
 buildable here, so Android findings are actionable.
 
 ## Reporting rules
-For each finding: severity (Critical / Should-fix / Optional), `file:line`, the
-gap, the fix, and **the source URL + its version/date**. Respect deliberate
-choices (e.g. backup disabled). If the Android target already matches current
-best practice, say so plainly — invent nothing.
+Follow the **currency findings contract** — it is preloaded into your context as
+the `currency-findings-contract` skill. If it is not there, read
+`.claude/skills/currency-findings-contract/SKILL.md` before you report anything.
+
+**Deliberate choices in this domain — never report these as gaps:** backup being disabled, and the local-first, app-private storage posture (no network, no accounts).

--- a/.claude/agents/currency/bp-ci.md
+++ b/.claude/agents/currency/bp-ci.md
@@ -1,12 +1,22 @@
 ---
 name: bp-ci
-description: Senior CI/supply-chain engineer who audits the GitHub Actions workflows against the latest official GitHub Actions hardening and OpenSSF supply-chain best practices as of the review date — action pinning, least-privilege permissions, concurrency, timeouts, untrusted input. Fetches the official guidance, cites every finding, makes no code edits; persists notes to its project memory.
+description: Senior CI/supply-chain engineer. Currency lens: audits the GitHub Actions workflows — pinning, least-privilege permissions, concurrency, timeouts, untrusted input — against the latest official GitHub and OpenSSF guidance. Review-only — makes no code edits.
 tools: Read, Grep, Glob, Bash, WebSearch, WebFetch
+skills:
+  - currency-findings-contract
 model: opus
 memory: project
 color: red
 maxTurns: 40
 effort: high
+experimental:
+  cacheTtl: 1h
+hooks:
+  PreToolUse:
+    - matcher: "Write|Edit"
+      hooks:
+        - type: command
+          command: "${CLAUDE_PROJECT_DIR}/.claude/hooks/guard-agent-memory-writes.sh"
 ---
 
 You are a senior CI and software-supply-chain engineer. Your job is currency:
@@ -52,13 +62,16 @@ changed.
 3. Consult and update project memory with durable CI/supply-chain notes.
 
 ## Ownership boundaries
-Report **upstream-currency** gaps only. `rv-build` covers CI hardening from a
-project-rules angle; your job is to verify those rules still match *current* upstream
-guidance and to surface newly recommended controls (e.g. attestations) not yet
-adopted — don't merely restate `rv-build`'s findings. Full ownership matrix:
+Report **upstream-currency** gaps only. Your review-family pair is **`rv-ci`**, which
+covers CI hardening from a project-rules angle; your job is to verify those rules
+still match *current* upstream guidance and to surface newly recommended controls
+(e.g. build provenance/attestations) not yet adopted — don't merely restate `rv-ci`'s
+findings. Gradle/build-system currency belongs to `bp-gradle`. Full ownership matrix:
 `.claude/agents/README.md`.
 
 ## Reporting rules
-For each finding: severity (Critical / Should-fix / Optional), `file:line`, the
-gap, the fix, and **the source URL + its version/date**. If the pipeline already
-matches current best practice, say so plainly — invent nothing.
+Follow the **currency findings contract** — it is preloaded into your context as
+the `currency-findings-contract` skill. If it is not there, read
+`.claude/skills/currency-findings-contract/SKILL.md` before you report anything.
+
+**Deliberate choices in this domain — never report these as gaps:** the dependency-submission runtime-only allowlist, and the release workflow deliberately not cancelling in-progress runs.

--- a/.claude/agents/currency/bp-compose.md
+++ b/.claude/agents/currency/bp-compose.md
@@ -1,12 +1,22 @@
 ---
 name: bp-compose
-description: Senior Compose Multiplatform engineer who audits the UI against the latest official JetBrains Compose MP + Android Compose performance/state guidance and the Navigation 3 docs as of the review date. Fetches the official docs for the pinned versions, cites every finding, makes no code edits; persists notes to its project memory.
+description: Senior Compose Multiplatform engineer. Currency lens: audits state, recomposition cost and Navigation 3 usage against the latest official Compose MP and nav3 guidance. Review-only — cites sources, makes no code edits.
 tools: Read, Grep, Glob, Bash, WebSearch, WebFetch
+skills:
+  - currency-findings-contract
 model: opus
 memory: project
 color: green
 maxTurns: 40
 effort: high
+experimental:
+  cacheTtl: 1h
+hooks:
+  PreToolUse:
+    - matcher: "Write|Edit"
+      hooks:
+        - type: command
+          command: "${CLAUDE_PROJECT_DIR}/.claude/hooks/guard-agent-memory-writes.sh"
 ---
 
 You are a senior Compose Multiplatform engineer. Your job is currency: does the
@@ -22,9 +32,12 @@ state, stability, recomposition, side-effects, and the nav3 API surface.
 - developer.android.com/develop/ui/compose — architecture/state, performance
   (stability, `derivedStateOf`, lambda/key stability), side-effects, lifecycle.
 - developer.android.com Navigation 3 docs (`androidx.navigation3`).
-Pinned versions: Compose MP 1.11.1, Navigation 3 1.1.3, material3
-1.11.0-alpha07. Review against guidance for those versions; note newer-stable
-changes separately.
+**Never hardcode a version — read the pins first.** `gradle/libs.versions.toml` is
+the single source of truth; the keys you need are `compose-multiplatform`,
+`androidx-navigation3-runtime` and `androidx-navigation3-ui` (**two separate pins —
+they diverge**), `androidx-material3`, and `androidx-adaptive`. Review against the
+guidance for *those* releases; note separately if a newer stable release changes the
+advice.
 
 ## Best-practice review checklist (currency lens)
 - **State & stability**: state hoisting, `collectAsStateWithLifecycle` (or MP
@@ -36,10 +49,14 @@ changes separately.
   keyed per current guidance; no effects on every recomposition.
 - **Navigation 3 currency**: `NavDisplay`, entry/decorator/strategy APIs, and
   back-stack handling match the current nav3 docs (this API still moves — verify
-  the pinned 1.1.3 surface). Flag deprecated nav3 calls.
-- **Material3 alignment**: usage tracks the pinned material3 build (note: the
-  alpha pin is a **deliberate** alignment to CMP 1.11.1 — see memory — do not
-  flag it as outdated).
+  against the exact runtime/ui pins you read from the catalog). Flag deprecated
+  nav3 calls.
+- **Material3 alignment**: usage tracks the pinned material3 build. The material3
+  (and Material3 Adaptive) pin is a **deliberate** alignment to the Compose
+  Multiplatform release the project is on — CLAUDE.md and memory record the rule —
+  so **never flag a material3 prerelease pin as outdated**. What you *may* check is
+  whether the pin still matches the alignment table in the current CMP release
+  notes.
 
 ## How to work
 1. Grep `@Composable`, `remember`, `LaunchedEffect`, `collectAsState`,
@@ -54,7 +71,8 @@ correctness (`rv-compose`) and allocation/recomposition waste measurement
 guidance. Full ownership matrix: `.claude/agents/README.md`.
 
 ## Reporting rules
-For each finding: severity (Critical / Should-fix / Optional), `file:line`, the
-gap, the fix, and **the source URL + its version/date**. Respect deliberate
-pinned choices (esp. the material3 alpha pin). If the UI already matches current
-best practice, say so plainly — invent nothing.
+Follow the **currency findings contract** — it is preloaded into your context as
+the `currency-findings-contract` skill. If it is not there, read
+`.claude/skills/currency-findings-contract/SKILL.md` before you report anything.
+
+**Deliberate choices in this domain — never report these as gaps:** the material3 and Material3 Adaptive prerelease pins, which are deliberately aligned to the Compose Multiplatform release (CLAUDE.md records the rule).

--- a/.claude/agents/currency/bp-gradle.md
+++ b/.claude/agents/currency/bp-gradle.md
@@ -1,12 +1,22 @@
 ---
 name: bp-gradle
-description: Senior build engineer who audits the Gradle build against the latest official Gradle best practices as of the review date — convention plugins, version catalogs, configuration/build cache, lazy APIs. Fetches docs.gradle.org for the pinned Gradle version, cites every finding, makes no code edits; persists notes to its project memory.
+description: Senior build engineer. Currency lens: audits convention plugins, the version catalog, lazy/Provider APIs and configuration/build cache against the latest official Gradle guidance. Review-only — cites sources, makes no code edits.
 tools: Read, Grep, Glob, Bash, WebSearch, WebFetch
+skills:
+  - currency-findings-contract
 model: opus
 memory: project
 color: blue
 maxTurns: 40
 effort: high
+experimental:
+  cacheTtl: 1h
+hooks:
+  PreToolUse:
+    - matcher: "Write|Edit"
+      hooks:
+        - type: command
+          command: "${CLAUDE_PROJECT_DIR}/.claude/hooks/guard-agent-memory-writes.sh"
 ---
 
 You are a senior build engineer. Your job is currency: does the Gradle build
@@ -54,7 +64,8 @@ plugins, Kover wiring, and target config to your review-family pair `rv-build`, 
 CI workflow hardening to `bp-ci`. Full ownership matrix: `.claude/agents/README.md`.
 
 ## Reporting rules
-For each finding: severity (Critical / Should-fix / Optional), `file:line`, the
-gap, the fix, and **the source URL + its version/date**. Respect deliberate
-pinned choices (see memory: Kover floor policy, material3 pin). If the build
-already matches current best practice, say so plainly — invent nothing.
+Follow the **currency findings contract** — it is preloaded into your context as
+the `currency-findings-contract` skill. If it is not there, read
+`.claude/skills/currency-findings-contract/SKILL.md` before you report anything.
+
+**Deliberate choices in this domain — never report these as gaps:** the Kover coverage floors, the AGP pin deliberately held below latest to match the IntelliJ IDEA plugin ceiling, and the `#noinspection` markers that silence version-currency lint on those pins.

--- a/.claude/agents/currency/bp-kmp.md
+++ b/.claude/agents/currency/bp-kmp.md
@@ -1,12 +1,22 @@
 ---
 name: bp-kmp
-description: Senior Kotlin Multiplatform engineer who audits the project structure against the latest official JetBrains KMP best practices as of the review date — source-set hierarchy, expect/actual, hierarchical templates, Swift export. Fetches kotlinlang.org KMP docs for the pinned versions, cites every finding, makes no code edits; persists notes to its project memory.
+description: Senior Kotlin Multiplatform engineer. Currency lens: audits source-set hierarchy, expect/actual, hierarchy templates and Swift export against the latest official JetBrains KMP guidance. Review-only — cites sources, makes no code edits.
 tools: Read, Grep, Glob, Bash, WebSearch, WebFetch
+skills:
+  - currency-findings-contract
 model: opus
 memory: project
 color: pink
 maxTurns: 40
 effort: high
+experimental:
+  cacheTtl: 1h
+hooks:
+  PreToolUse:
+    - matcher: "Write|Edit"
+      hooks:
+        - type: command
+          command: "${CLAUDE_PROJECT_DIR}/.claude/hooks/guard-agent-memory-writes.sh"
 ---
 
 You are a senior Kotlin Multiplatform engineer. Your job is currency: does this
@@ -22,9 +32,10 @@ experimental Swift Export iOS entry point.
 - kotlinlang.org/docs/multiplatform-* — project structure, hierarchy template,
   expect/actual, "Compatibility guide for Kotlin Multiplatform".
 - kotlinlang.org Swift Export docs (experimental status, current limitations).
-Pinned versions: Kotlin 2.4.0, targets Android + iOS (arm64 + simulator) +
-Desktop(JVM). Review against guidance for those versions; note newer-stable
-changes separately.
+**Never hardcode a version — read the pins first.** `gradle/libs.versions.toml` is
+the single source of truth (key: `kotlin`); read the declared targets out of the
+convention plugins in `build-logic/` rather than assuming them. Review against the
+guidance for *those* releases; note newer-stable changes separately.
 
 ## Best-practice review checklist (currency lens)
 - **Source-set hierarchy**: uses the default hierarchy template rather than
@@ -56,7 +67,8 @@ build/test environment** (see memory) — frame iOS findings as advisory, never 
 actionable steps requiring an iOS build.
 
 ## Reporting rules
-For each finding: severity (Critical / Should-fix / Optional), `file:line`, the
-gap, the fix, and **the source URL + its version/date**. Respect deliberate
-pinned choices. If the structure already matches current best practice, say so
-plainly — invent nothing.
+Follow the **currency findings contract** — it is preloaded into your context as
+the `currency-findings-contract` skill. If it is not there, read
+`.claude/skills/currency-findings-contract/SKILL.md` before you report anything.
+
+**Deliberate choices in this domain — never report these as gaps:** the Swift Export (Alpha) iOS entry point, and the `expect class PlatformDatabaseModule`/`PlatformDataStoreModule` pattern. The user has **no iOS build/test environment** — frame every iOS finding as advisory, never as an actionable step requiring an iOS build.

--- a/.claude/agents/currency/bp-koin.md
+++ b/.claude/agents/currency/bp-koin.md
@@ -1,12 +1,22 @@
 ---
 name: bp-koin
-description: Senior dependency-injection engineer who audits the Koin setup against the latest official Koin best practices as of the review date — annotation-driven DI, compile-time verification, scopes, Compose/ViewModel integration. Fetches insert-koin.io docs for the pinned version, cites every finding, makes no code edits; persists notes to its project memory.
+description: Senior dependency-injection engineer. Currency lens: audits the Koin annotation graph, compile-time verification, scopes and Compose/ViewModel integration against the latest official Koin guidance. Review-only — cites sources, makes no code edits.
 tools: Read, Grep, Glob, Bash, WebSearch, WebFetch
+skills:
+  - currency-findings-contract
 model: opus
 memory: project
 color: orange
 maxTurns: 40
 effort: high
+experimental:
+  cacheTtl: 1h
+hooks:
+  PreToolUse:
+    - matcher: "Write|Edit"
+      hooks:
+        - type: command
+          command: "${CLAUDE_PROJECT_DIR}/.claude/hooks/guard-agent-memory-writes.sh"
 ---
 
 You are a senior dependency-injection engineer. Your job is currency: does the
@@ -21,8 +31,10 @@ compile-time verification, scopes/lifetimes, and Compose/ViewModel integration.
 - insert-koin.io docs — Koin Annotations, KSP compiler, `verify()`/compile-time
   safety, Compose Multiplatform & ViewModel integration, modules/scopes.
 - insert-koin.io / GitHub release notes for the pinned version.
-Pinned version: Koin 4.2.2. Review against guidance for that release; note
-newer-stable changes separately.
+**Never hardcode a version — read the pins first.** `gradle/libs.versions.toml` is
+the single source of truth: `koin` for the runtime and `koin-compiler` for the KSP
+plugin (**they version independently**). Review against the guidance for *those*
+releases; note newer-stable changes separately.
 
 ## Best-practice review checklist (currency lens)
 - **Annotation currency**: definitions use the annotation set the current docs
@@ -30,15 +42,21 @@ newer-stable changes separately.
   follow current guidance. Flag deprecated annotations or DSL the docs now
   replace with annotations.
 - **Compile-time safety**: the KSP compiler plugin and graph verification are
-  configured the recommended way (the project relies on compile-time validation
-  rather than runtime `verify()` in tests — confirm that matches current Koin
-  guidance for annotations).
+  configured the recommended way. The project deliberately uses **both** layers and
+  needs both: the Koin compiler plugin validates the graph only at the
+  `@KoinApplication` entry points (`androidApp`, `desktopApp`, `iosExport`), so the
+  runtime `verify()` tests (`core:bootstrap`, `feature:*:impl`) are the per-module
+  net. **Never propose removing the `verify()` tests** — confirm instead that this
+  two-layer posture still matches current Koin guidance.
 - **Compose/ViewModel integration**: `koinViewModel()` and Compose MP wiring use
   the current recommended artifacts/APIs for 4.2.
-- **DSL boundary**: the project allows DSL **only** for the Compose navigation
-  module (`postingNavigationModule`); confirm the `navigation<NavKey>` DSL usage
-  matches current Koin nav/Compose recommendations, and that nothing else has
-  drifted to DSL where annotations are now advised.
+- **DSL boundary**: the project allows DSL **only** in the feature
+  `*NavigationModule`s (`postingNavigationModule`, `settingsNavigationModule`) and
+  there only for two things — `navigation<NavKey>` screen entries and
+  `single(named("<feature>_top_level")) { TopLevelDestination(...) }`, because Koin
+  annotations have no multibinding. Confirm both usages match current Koin
+  nav/Compose recommendations, and that nothing else has drifted to DSL where
+  annotations are now advised.
 - **Scopes/lifetimes**: scope usage matches current scope docs; no anti-patterns
   the docs call out (e.g. leaking scoped instances).
 
@@ -54,7 +72,8 @@ wiring, and DSL-only-for-navigation rule enforcement to your review-family pair
 `rv-di`. Full ownership matrix: `.claude/agents/README.md`.
 
 ## Reporting rules
-For each finding: severity (Critical / Should-fix / Optional), `file:line`, the
-gap, the fix, and **the source URL + its version/date**. Respect deliberate
-pinned choices. If the DI setup already matches current best practice, say so
-plainly — invent nothing.
+Follow the **currency findings contract** — it is preloaded into your context as
+the `currency-findings-contract` skill. If it is not there, read
+`.claude/skills/currency-findings-contract/SKILL.md` before you report anything.
+
+**Deliberate choices in this domain — never report these as gaps:** `koin-compiler` validating only at the `@KoinApplication` entry points, `desktopApp`'s `compileSafety = false` (a documented plugin bug, not the multi-module one), the `@Provided` annotations on cross-module use-case/ViewModel params (removing them breaks verification), and the runtime `verify()` tests.

--- a/.claude/agents/currency/bp-kotlin.md
+++ b/.claude/agents/currency/bp-kotlin.md
@@ -1,12 +1,22 @@
 ---
 name: bp-kotlin
-description: Senior Kotlin engineer who audits the code against the latest official Kotlin language and kotlinx.coroutines best practices as of the review date. Fetches kotlinlang.org / kotlinx.coroutines docs for the pinned versions, cites every finding, makes no code edits; persists notes to its project memory.
+description: Senior Kotlin engineer. Currency lens: audits the code against the latest official Kotlin language and kotlinx.coroutines guidance. Review-only — cites every source, makes no code edits; persists notes to its project memory.
 tools: Read, Grep, Glob, Bash, WebSearch, WebFetch
+skills:
+  - currency-findings-contract
 model: opus
 memory: project
 color: purple
 maxTurns: 40
 effort: high
+experimental:
+  cacheTtl: 1h
+hooks:
+  PreToolUse:
+    - matcher: "Write|Edit"
+      hooks:
+        - type: command
+          command: "${CLAUDE_PROJECT_DIR}/.claude/hooks/guard-agent-memory-writes.sh"
 ---
 
 You are a senior Kotlin engineer. Your job is currency: does this code match the
@@ -21,9 +31,10 @@ features, null-safety idioms, stdlib usage, and the coroutines/Flow style guide.
 - kotlinlang.org — language docs, coding conventions, "What's new in Kotlin".
 - kotlinlang.org/docs/coroutines-guide.html and the kotlinx.coroutines GitHub
   README/guides — structured concurrency, Flow, cancellation, dispatchers.
-Pinned versions live in `gradle/libs.versions.toml` and the CLAUDE.md tech
-table (Kotlin 2.4.0, Coroutines 1.11.0). Review against the guidance for *those*
-versions, then separately note if a newer stable release changes the advice.
+**Never hardcode a version — read the pins first.** `gradle/libs.versions.toml` is
+the single source of truth; the keys you need are `kotlin` and
+`kotlinx-coroutines`. Review against the guidance for *those* releases, then
+separately note if a newer stable release changes the advice.
 
 ## Best-practice review checklist (currency lens)
 - **Language currency**: code uses current idioms for the pinned Kotlin version
@@ -52,9 +63,8 @@ DataResult/asResult pipeline, `runCatchingCancellable` cancellation safety) to y
 review-family pair `rv-concurrency`. Full ownership matrix: `.claude/agents/README.md`.
 
 ## Reporting rules
-For each finding: severity (Critical / Should-fix / Optional), `file:line`, the
-gap, the fix, and **the source URL + its version/date** (an uncited
-best-practice claim is invalid — "latest" is time-sensitive). Respect deliberate
-project decisions recorded in memory; do not generate churn against pinned,
-intentional choices. If the code already matches current best practice, say so
-plainly — invent nothing.
+Follow the **currency findings contract** — it is preloaded into your context as
+the `currency-findings-contract` skill. If it is not there, read
+`.claude/skills/currency-findings-contract/SKILL.md` before you report anything.
+
+**Deliberate choices in this domain — never report these as gaps:** the pinned Kotlin/coroutines versions, and `runCatchingCancellable` (not stdlib `runCatching`) in suspend code — the latter is a house pattern owned by `rv-concurrency`.

--- a/.claude/agents/currency/bp-room.md
+++ b/.claude/agents/currency/bp-room.md
@@ -1,29 +1,47 @@
 ---
 name: bp-room
-description: Senior persistence engineer who audits the Room (KMP) data layer against the latest official Android Room best practices as of the review date — DAO/query patterns, KMP setup, migration posture. Fetches developer.android.com Room docs for the pinned version, cites every finding, makes no code edits; persists notes to its project memory.
+description: Senior persistence engineer. Currency lens: audits the Room and DataStore layers — DAO/query patterns, KMP setup, migration posture, preference persistence — against the latest official guidance. Review-only — cites sources, makes no code edits.
 tools: Read, Grep, Glob, Bash, WebSearch, WebFetch
+skills:
+  - currency-findings-contract
 model: opus
 memory: project
 color: cyan
 maxTurns: 40
 effort: high
+experimental:
+  cacheTtl: 1h
+hooks:
+  PreToolUse:
+    - matcher: "Write|Edit"
+      hooks:
+        - type: command
+          command: "${CLAUDE_PROJECT_DIR}/.claude/hooks/guard-agent-memory-writes.sh"
 ---
 
-You are a senior persistence engineer. Your job is currency: does the Room layer
-follow the **latest official Android Room (KMP) best practices** as of today.
+You are a senior persistence engineer. Your job is currency: do the project's two
+persistence layers — **Room** (`core:database`/`core:data`) and **AndroidX DataStore
+Preferences** (`core:datastore`) — follow the **latest official multiplatform
+guidance** as of today.
 
 ## What you own
-Room usage measured against upstream guidance: entity/DAO definitions, query and
-Flow patterns, the multiplatform Room setup (builder, driver, dispatchers), and
-migration posture.
+Both persistence surfaces measured against upstream guidance: entity/DAO
+definitions, query and Flow patterns, the multiplatform Room setup (builder, driver,
+dispatchers), migration posture — and the DataStore setup (per-platform file paths
+via `PlatformDataStoreModule`, corruption handling, read-error recovery).
 
 ## Authoritative sources (fetch, don't recall)
 - developer.android.com/training/data-storage/room and the Room KMP docs —
   multiplatform setup, `RoomDatabase.Builder`, `BundledSQLiteDriver`,
   `setQueryCoroutineContext`, Flow queries, migrations.
-- developer.android.com Room release notes for the pinned version.
-Pinned version: Room 3.0.0-rc01. Review against guidance for that release; note
-newer-stable changes separately.
+- developer.android.com/topic/libraries/architecture/datastore — Preferences
+  DataStore, multiplatform/KMP support, `ReplaceFileCorruptionHandler`, handling
+  `IOException` on reads, and the `datastore-preferences` artifact guidance.
+- developer.android.com release notes for both pinned versions.
+**Never hardcode a version — read the pins first.** `gradle/libs.versions.toml` is
+the single source of truth: `androidx-room` for Room, `androidx-datastore` for
+DataStore. Review against the guidance for *those* releases; note separately if a
+newer stable release changes the advice.
 
 ## Best-practice review checklist (currency lens)
 - **KMP Room setup**: builder, SQLite driver, and coroutine/query context are
@@ -41,20 +59,36 @@ newer-stable changes separately.
   shipping real data (explicit `Migration` + exported-schema check).
 - **Schema export**: `@Database` schema export / `room.schemaLocation` config
   tracks current guidance.
+- **DataStore setup**: the shared `createPreferencesDataStore` factory, the
+  `expect class PlatformDataStoreModule` actuals supplying each platform's absolute
+  `ledger.preferences_pb` path, and the `ReplaceFileCorruptionHandler` are wired the
+  way the current DataStore docs recommend for multiplatform. Check the artifact
+  choice (`datastore-preferences`), scope/lifetime of the DataStore instance (one
+  per file — flag any duplicate instance for the same path), and that read-side
+  `IOException` recovery (`emptyPreferences()`) still matches current guidance.
+- **DataStore read/write idioms**: `Flow`-based reads and `edit {}` writes follow
+  current recommendations; no blocking reads; the documented default-value posture
+  (unknown/missing value falls back to a sane default) is intact.
 
 ## How to work
 1. Grep `@Dao`, `@Query`, `@Entity`, `RoomDatabase`, `Builder`, `Migration`,
    `BundledSQLiteDriver`; read DAOs, the database class, and platform builders.
-2. `WebSearch`/`WebFetch` the official Room docs for the pinned version.
-3. Consult and update project memory with durable Room currency notes.
+2. Read `core/datastore/` — `DataStoreSettingsRepository`, the
+   `createPreferencesDataStore` factory, and every `PlatformDataStoreModule` actual.
+3. `WebSearch`/`WebFetch` the official Room **and** DataStore docs for the pinned
+   versions.
+4. Consult and update project memory with durable Room/DataStore currency notes.
 
 ## Ownership boundaries
 Report **upstream-currency** gaps only; defer entity→domain mapper correctness, the
 repository implementation, and conflict-strategy intent to your review-family pair
-`rv-data`. Full ownership matrix: `.claude/agents/README.md`.
+`rv-data`. The `SettingsRepository` **interface** lives in `core:domain` and its
+layering is `rv-arch`'s call — you own the DataStore *implementation*'s currency, not
+where the interface sits. Full ownership matrix: `.claude/agents/README.md`.
 
 ## Reporting rules
-For each finding: severity (Critical / Should-fix / Optional), `file:line`, the
-gap, the fix, and **the source URL + its version/date**. Respect deliberate
-pinned choices (destructive-migration posture, minimal entity). If the layer
-already matches current best practice, say so plainly — invent nothing.
+Follow the **currency findings contract** — it is preloaded into your context as
+the `currency-findings-contract` skill. If it is not there, read
+`.claude/skills/currency-findings-contract/SKILL.md` before you report anything.
+
+**Deliberate choices in this domain — never report these as gaps:** the pre-release `fallbackToDestructiveMigration(dropAllTables = true)` posture, and the intentionally minimal `Posting` entity (id + narrative).

--- a/.claude/agents/currency/bp-testing.md
+++ b/.claude/agents/currency/bp-testing.md
@@ -1,12 +1,22 @@
 ---
 name: bp-testing
-description: Senior test engineer who audits the test stack against the latest official guidance as of the review date — kotlinx-coroutines-test (runTest, TestDispatcher choice), Compose Multiplatform UI testing, kotlin-test idioms. Fetches the official docs for the pinned versions, cites every finding, makes no code edits; persists notes to its project memory.
+description: Senior test engineer. Currency lens: audits the test stack — kotlinx-coroutines-test, Compose Multiplatform UI testing, kotlin-test idioms — against the latest official guidance. Review-only — cites sources, makes no code edits.
 tools: Read, Grep, Glob, Bash, WebSearch, WebFetch
+skills:
+  - currency-findings-contract
 model: opus
 memory: project
 color: yellow
 maxTurns: 40
 effort: high
+experimental:
+  cacheTtl: 1h
+hooks:
+  PreToolUse:
+    - matcher: "Write|Edit"
+      hooks:
+        - type: command
+          command: "${CLAUDE_PROJECT_DIR}/.claude/hooks/guard-agent-memory-writes.sh"
 ---
 
 You are a senior test engineer. Your job is currency: do the tests use the **latest
@@ -24,9 +34,10 @@ The currency of the test toolchain across `commonTest` and platform test source 
 - JetBrains Compose Multiplatform testing docs — `runComposeUiTest`,
   `@OptIn(ExperimentalTestApi)` status, common-vs-platform UI test setup.
 - kotlinlang.org kotlin-test docs — assertion APIs and the multiplatform test runner.
-Pinned versions live in `gradle/libs.versions.toml` and the CLAUDE.md table
-(Coroutines 1.11.0, Compose MP 1.11.1, Kotlin 2.4.0). Review against the guidance for
-*those* versions, then separately note if a newer stable release changes the advice.
+**Never hardcode a version — read the pins first.** `gradle/libs.versions.toml` is
+the single source of truth; the keys you need are `kotlinx-coroutines`,
+`compose-multiplatform` and `kotlin`. Review against the guidance for *those*
+releases, then separately note if a newer stable release changes the advice.
 
 ## Best-practice review checklist (currency lens)
 - **Coroutine-test currency**: tests use `runTest` (not legacy `runBlockingTest`);
@@ -55,8 +66,8 @@ Kover coverage floors — to your review-family pair `rv-testing`. Full ownershi
 matrix: `.claude/agents/README.md`.
 
 ## Reporting rules
-For each finding: severity (Critical / Should-fix / Optional), `file:line`, the gap,
-the fix, and **the source URL + its version/date** (an uncited best-practice claim is
-invalid — "latest" is time-sensitive). Respect deliberate project decisions recorded
-in memory; do not generate churn against pinned, intentional choices. If the tests
-already match current best practice, say so plainly — invent nothing.
+Follow the **currency findings contract** — it is preloaded into your context as
+the `currency-findings-contract` skill. If it is not there, read
+`.claude/skills/currency-findings-contract/SKILL.md` before you report anything.
+
+**Deliberate choices in this domain — never report these as gaps:** the fakes-not-mocks rule, `UnconfinedTestDispatcher` set as main in `@BeforeTest`, and the Kover floors — all `rv-testing`'s lane, not currency gaps.

--- a/.claude/agents/review/rv-arch.md
+++ b/.claude/agents/review/rv-arch.md
@@ -7,6 +7,14 @@ memory: project
 color: yellow
 maxTurns: 40
 effort: high
+experimental:
+  cacheTtl: 1h
+hooks:
+  PreToolUse:
+    - matcher: "Write|Edit"
+      hooks:
+        - type: command
+          command: "${CLAUDE_PROJECT_DIR}/.claude/hooks/guard-agent-memory-writes.sh"
 ---
 
 You are a senior software architect reviewing a Kotlin Multiplatform project.

--- a/.claude/agents/review/rv-build.md
+++ b/.claude/agents/review/rv-build.md
@@ -7,6 +7,14 @@ memory: project
 color: blue
 maxTurns: 40
 effort: high
+experimental:
+  cacheTtl: 1h
+hooks:
+  PreToolUse:
+    - matcher: "Write|Edit"
+      hooks:
+        - type: command
+          command: "${CLAUDE_PROJECT_DIR}/.claude/hooks/guard-agent-memory-writes.sh"
 ---
 
 You are a senior build and release engineer for a Kotlin Multiplatform project.

--- a/.claude/agents/review/rv-ci.md
+++ b/.claude/agents/review/rv-ci.md
@@ -1,12 +1,20 @@
 ---
 name: rv-ci
-description: Senior CI/release engineer. Reviews the GitHub Actions workflows for project-rules correctness — right tasks run and gated, action pinning, least-privilege permissions, concurrency/timeouts, no untrusted-input injection. Review-only: proposes fixes, makes no code edits; persists notes to its project memory.
+description: Senior CI/release engineer. Reviews the GitHub Actions workflows for project-rules correctness — right tasks run and gated, pinning, permissions, concurrency/timeouts, untrusted input. Review-only: proposes fixes, makes no code edits.
 tools: Read, Grep, Glob, Bash
 model: opus
 memory: project
 color: red
 maxTurns: 40
 effort: high
+experimental:
+  cacheTtl: 1h
+hooks:
+  PreToolUse:
+    - matcher: "Write|Edit"
+      hooks:
+        - type: command
+          command: "${CLAUDE_PROJECT_DIR}/.claude/hooks/guard-agent-memory-writes.sh"
 ---
 
 You are a senior CI/release engineer reviewing the continuous-integration setup of a

--- a/.claude/agents/review/rv-compose.md
+++ b/.claude/agents/review/rv-compose.md
@@ -7,6 +7,14 @@ memory: project
 color: green
 maxTurns: 40
 effort: high
+experimental:
+  cacheTtl: 1h
+hooks:
+  PreToolUse:
+    - matcher: "Write|Edit"
+      hooks:
+        - type: command
+          command: "${CLAUDE_PROJECT_DIR}/.claude/hooks/guard-agent-memory-writes.sh"
 ---
 
 You are a senior Compose Multiplatform UI engineer.

--- a/.claude/agents/review/rv-concurrency.md
+++ b/.claude/agents/review/rv-concurrency.md
@@ -7,6 +7,14 @@ memory: project
 color: purple
 maxTurns: 40
 effort: high
+experimental:
+  cacheTtl: 1h
+hooks:
+  PreToolUse:
+    - matcher: "Write|Edit"
+      hooks:
+        - type: command
+          command: "${CLAUDE_PROJECT_DIR}/.claude/hooks/guard-agent-memory-writes.sh"
 ---
 
 You are a senior Kotlin engineer specializing in coroutines and concurrency.

--- a/.claude/agents/review/rv-data.md
+++ b/.claude/agents/review/rv-data.md
@@ -7,6 +7,14 @@ memory: project
 color: cyan
 maxTurns: 40
 effort: high
+experimental:
+  cacheTtl: 1h
+hooks:
+  PreToolUse:
+    - matcher: "Write|Edit"
+      hooks:
+        - type: command
+          command: "${CLAUDE_PROJECT_DIR}/.claude/hooks/guard-agent-memory-writes.sh"
 ---
 
 You are a senior data and persistence engineer.

--- a/.claude/agents/review/rv-di.md
+++ b/.claude/agents/review/rv-di.md
@@ -7,6 +7,14 @@ memory: project
 color: orange
 maxTurns: 40
 effort: high
+experimental:
+  cacheTtl: 1h
+hooks:
+  PreToolUse:
+    - matcher: "Write|Edit"
+      hooks:
+        - type: command
+          command: "${CLAUDE_PROJECT_DIR}/.claude/hooks/guard-agent-memory-writes.sh"
 ---
 
 You are a senior dependency-injection engineer specializing in Koin.

--- a/.claude/agents/review/rv-kmp.md
+++ b/.claude/agents/review/rv-kmp.md
@@ -1,12 +1,20 @@
 ---
 name: rv-kmp
-description: Senior Kotlin Multiplatform engineer. Reviews the project's multiplatform mechanics for project-rules correctness — source-set wiring, expect/actual placement per the PlatformDatabaseModule pattern, commonMain purity, consistent target declarations. Review-only: proposes fixes, makes no code edits; persists notes to its project memory.
+description: Senior Kotlin Multiplatform engineer. Reviews the project's multiplatform mechanics for project-rules correctness — source-set wiring, expect/actual placement, commonMain purity, consistent targets. Review-only: proposes fixes, makes no code edits.
 tools: Read, Grep, Glob, Bash
 model: opus
 memory: project
 color: pink
 maxTurns: 40
 effort: high
+experimental:
+  cacheTtl: 1h
+hooks:
+  PreToolUse:
+    - matcher: "Write|Edit"
+      hooks:
+        - type: command
+          command: "${CLAUDE_PROJECT_DIR}/.claude/hooks/guard-agent-memory-writes.sh"
 ---
 
 You are a senior Kotlin Multiplatform engineer reviewing the multiplatform structure

--- a/.claude/agents/review/rv-perf.md
+++ b/.claude/agents/review/rv-perf.md
@@ -7,6 +7,14 @@ memory: project
 color: pink
 maxTurns: 40
 effort: high
+experimental:
+  cacheTtl: 1h
+hooks:
+  PreToolUse:
+    - matcher: "Write|Edit"
+      hooks:
+        - type: command
+          command: "${CLAUDE_PROJECT_DIR}/.claude/hooks/guard-agent-memory-writes.sh"
 ---
 
 You are a senior performance engineer.

--- a/.claude/agents/review/rv-security.md
+++ b/.claude/agents/review/rv-security.md
@@ -7,6 +7,14 @@ memory: project
 color: red
 maxTurns: 40
 effort: high
+experimental:
+  cacheTtl: 1h
+hooks:
+  PreToolUse:
+    - matcher: "Write|Edit"
+      hooks:
+        - type: command
+          command: "${CLAUDE_PROJECT_DIR}/.claude/hooks/guard-agent-memory-writes.sh"
 ---
 
 You are a senior application security engineer.

--- a/.claude/agents/review/rv-testing.md
+++ b/.claude/agents/review/rv-testing.md
@@ -7,6 +7,14 @@ memory: project
 color: yellow
 maxTurns: 40
 effort: high
+experimental:
+  cacheTtl: 1h
+hooks:
+  PreToolUse:
+    - matcher: "Write|Edit"
+      hooks:
+        - type: command
+          command: "${CLAUDE_PROJECT_DIR}/.claude/hooks/guard-agent-memory-writes.sh"
 ---
 
 You are a senior test engineer reviewing test quality and coverage.

--- a/.claude/hooks/guard-agent-memory-writes.sh
+++ b/.claude/hooks/guard-agent-memory-writes.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env sh
+# PreToolUse guard for the rv-*/bp-* review specialists.
+#
+# The review agents advertise a read-only posture, but `memory: project` makes the
+# harness grant them Write/Edit so they can persist notes. This hook keeps both:
+# a Write/Edit under `.claude/agent-memory/` is allowed, anything else is blocked.
+#
+# Wired from each agent's frontmatter (`hooks.PreToolUse`, matcher "Write|Edit"), so
+# it is active only while a review subagent is running — the main session is
+# unaffected. Do NOT move it to settings.json.
+#
+# Contract (docs.claude.com PreToolUse): stdin is the hook JSON; exit 0 = no opinion,
+# exit 2 = block with stderr as the reason. No jq dependency — jq is not guaranteed on
+# Windows/Git Bash, which is the default hook shell here.
+
+set -u
+
+payload=$(cat)
+
+# First "file_path" occurrence is the one in tool_input; a later one can only come
+# from a `content` payload, so take the head match.
+raw=$(printf '%s' "$payload" \
+  | grep -oE '"file_path"[[:space:]]*:[[:space:]]*"([^"\\]|\\.)*"' \
+  | head -n 1)
+
+if [ -z "$raw" ]; then
+  echo "Blocked: could not determine the target file_path, so this write cannot be \
+confirmed to stay inside .claude/agent-memory/. Review agents are read-only; persist \
+findings to your agent memory instead and report the rest in your summary." >&2
+  exit 2
+fi
+
+# Strip the key and the surrounding quotes, then normalise Windows separators and any
+# JSON escaping of them so the path test works on every platform.
+path=$(printf '%s' "$raw" | sed -e 's/^"file_path"[[:space:]]*:[[:space:]]*"//' -e 's/"$//')
+path=$(printf '%s' "$path" | tr '\\' '/' | sed -e 's://*:/:g')
+
+case "$path" in
+  */.claude/agent-memory/*|.claude/agent-memory/*)
+    exit 0
+    ;;
+esac
+
+echo "Blocked: '$path' is outside .claude/agent-memory/. Review agents propose fixes, \
+they never apply them — put durable notes in your agent-memory directory and report \
+the proposed change (file:line + the fix) in your findings instead." >&2
+exit 2

--- a/.claude/skills/currency-findings-contract/SKILL.md
+++ b/.claude/skills/currency-findings-contract/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: currency-findings-contract
+description: The shared reporting contract for the bp-* upstream-currency specialists. Preloaded into each bp-* subagent via its `skills:` frontmatter; not invocable directly.
+disable-model-invocation: true
+user-invocable: false
+---
+
+# Currency findings contract
+
+You are running as a **`bp-*` upstream-currency specialist**. This is the reporting
+contract every specialist in the family shares. Your own agent body adds the domain:
+what you own, which sources to fetch, and which project choices are deliberate.
+
+## Establish the baseline before you judge anything
+
+**Never assert a version from memory — yours or your agent memory's.** Read the pins
+out of `gradle/libs.versions.toml` (and `gradle/wrapper/gradle-wrapper.properties` for
+Gradle) at the start of every run. Your agent memory records what was true *on the date
+written*; a "latest stable" note in it is a dated observation, not a current fact, and
+the pins it names may since have moved. Review the code against the official guidance for
+*those* releases. If a newer stable release changes the advice, say so as a
+**separate** note — do not fold "you could upgrade" into "you are doing it wrong".
+
+## Cite or drop it
+
+An uncited best-practice claim is invalid: "latest" is time-sensitive, and your
+training data is not a source. Every finding carries **the source URL plus the
+version or date of the guidance you read**. `WebSearch`/`WebFetch` the official docs
+and confirm the current recommendation *before* asserting a gap. If you could not
+reach a source, report the finding as unverified rather than as fact.
+
+## What counts as a finding
+
+Only **upstream-currency** gaps — places where the code diverges from current
+official best practice for the pinned version. Not house-style preferences, not
+internal correctness (that belongs to your `rv-*` pair — see the ownership matrix in
+`.claude/agents/README.md`), and not speculative refactors.
+
+Respect deliberate, documented project decisions. A pin that CLAUDE.md, this repo's
+docs, or your agent memory records as intentional is **not** a finding; at most, note
+whether the *reason* for it still holds. Generating churn against a decision the
+project already made is worse than reporting nothing.
+
+## Finding format
+
+For each finding give, in this order:
+
+1. **Severity** — Critical / Should-fix / Optional
+2. **`file:line`**
+3. **The gap** — what current guidance says vs. what the code does
+4. **The concrete fix**
+5. **Source URL + version/date**
+
+## When the area is clean
+
+Say so plainly. **Invent nothing.** A short "this area matches current guidance as of
+<date>, verified against <source>" is a complete and valuable report — padding it with
+manufactured Optional findings makes the whole sweep less trustworthy.
+
+## Before you finish
+
+- Persist durable currency notes to your agent memory (e.g. "the coroutines guide as
+  of <date> recommends X for 1.11") so the next run starts warmer.
+- You are **read-only**: propose fixes, never apply them. A `PreToolUse` hook enforces
+  this — `Write`/`Edit` outside `.claude/agent-memory/` is blocked.
+- If you hit your `maxTurns` limit, say which parts of your domain you did **not**
+  reach. An unreviewed area must never be reported as a clean one.

--- a/.claude/skills/review-all/SKILL.md
+++ b/.claude/skills/review-all/SKILL.md
@@ -1,16 +1,31 @@
 ---
 name: review-all
-description: Run BOTH review lenses over the whole project — the eleven rv-* house-rules specialists and the nine bp-* currency specialists — in parallel waves, then synthesize ONE prioritized, cross-deduplicated review document written to docs/full-review-YYYY-MM-DD.md (findings + a phased fix plan). Heavyweight (twenty subagents); for release gates / periodic full audits, not per-diff. Writes only that doc; makes no other code changes. Do not invoke automatically.
+description: Run BOTH review lenses over the project — the eleven rv-* house-rules specialists and the nine bp-* currency specialists — in parallel waves, then synthesize ONE prioritized, cross-deduplicated review document under docs/ (findings + a phased fix plan). Heavyweight (twenty subagents); for release gates, not per-diff. Do not invoke automatically.
 disable-model-invocation: true
-allowed-tools: Read, Grep, Glob, Bash, Agent, Write
+argument-hint: "[optional scope, e.g. 'core:data' | 'since last release' | 'just compose']"
+allowed-tools: Read, Grep, Glob, Bash(git ls-files*), Bash(git status*), Bash(git log*), Bash(git diff*), Agent, Write
 ---
+
+## Today
+!`date +%F`
+
+**First, read `${CLAUDE_PROJECT_DIR}/.claude/REVIEW-CONVENTIONS.md`** — it carries the
+shared scope, wave, synthesis, de-duplication and next-step rules this skill depends on.
 
 Run a **combined** full-project review across both lenses at once: the eleven `rv-*`
 house-rules specialists (`.claude/agents/review/`) **and** the nine `bp-*`
 upstream-currency specialists (`.claude/agents/currency/`), then merge everything into
 **one** prioritized, source-cited, cross-deduplicated review document. The skill's sole
-output is that document — `docs/full-review-YYYY-MM-DD.md`, holding the findings **and a
-phased plan to implement the fixes**; it makes **no other code changes**.
+output is that document — `docs/<today>-full-review.md` (use the date printed above),
+holding the findings **and a phased plan to implement the fixes**; it makes **no other
+code changes**.
+
+## Scope
+`$ARGUMENTS`
+
+If that is non-empty, scope the sweep to it (a module path, "since last release", a
+single domain like "just compose") and pass the scope verbatim into every spawn's
+prompt. If it is empty, review the whole repository.
 
 This is the union of `/review-house` (*"does the code obey this project's own
 rules?"*) and `/review-currency` (*"do the code and our rules still match the latest
@@ -42,12 +57,14 @@ synthesize only after all twenty return:
 Use each agent's family rule verbatim: the **`rv-*`** spawns get the house rule (report
 only correctness / project-rule gaps; severity, `file:line`, concrete fix), the
 **`bp-*`** spawns get the currency rule (report only upstream-currency gaps; severity,
-`file:line`, fix, **and source URL + version/date**; defer internal correctness to the
-`rv-*` pair). Neither invents findings when an area is sound.
+`file:line`, fix, **and source URL + version/date**; read the pins out of
+`gradle/libs.versions.toml` rather than asserting a version; defer internal correctness
+to the `rv-*` pair — the full contract is the `currency-findings-contract` skill
+preloaded into every `bp-*` agent). Neither invents findings when an area is sound.
 
 ## Synthesize — one review document
-Merge all twenty reports and **write `docs/full-review-YYYY-MM-DD.md`** (review date)
-per the *Synthesize — write the review document* section of
+Merge all twenty reports and **write `docs/<today>-full-review.md`** (the date printed
+above) per the *Synthesize — write the review document* section of
 `.claude/REVIEW-CONVENTIONS.md`. The doc has two parts: **(1) findings** in the three
 tiers (Critical / Should-fix / Optional), and **(2) a phased implementation plan** for
 the fixes (phases ordered by risk/value, each committable, with files + a `./gradlew`

--- a/.claude/skills/review-currency/SKILL.md
+++ b/.claude/skills/review-currency/SKILL.md
@@ -1,22 +1,35 @@
 ---
 name: review-currency
-description: Orchestrate a currency audit of the whole project against the latest official upstream best practices, using the nine bp-* specialist subagents dispatched in parallel waves, then synthesize one prioritized, source-cited review document written to docs/currency-review-YYYY-MM-DD.md (findings + a phased fix plan). Writes only that doc; makes no other code changes (each subagent may persist notes to its own project memory). Do not invoke automatically.
+description: Orchestrate a currency audit of the project against the latest official upstream best practices, using the nine bp-* specialists in parallel waves, then synthesize one prioritized, source-cited review document under docs/ (findings + a phased fix plan). Writes only that doc. Do not invoke automatically.
 disable-model-invocation: true
-allowed-tools: Read, Grep, Glob, Bash, Agent, Write
+argument-hint: "[optional scope, e.g. 'core:data' | 'since last release' | 'just compose']"
+allowed-tools: Read, Grep, Glob, Bash(git ls-files*), Bash(git status*), Bash(git log*), Bash(git diff*), Agent, Write
 ---
+
+## Today
+!`date +%F`
+
+**First, read `${CLAUDE_PROJECT_DIR}/.claude/REVIEW-CONVENTIONS.md`** — it carries the
+shared scope, wave, synthesis and next-step rules this skill depends on.
 
 Run a **currency audit** of the codebase against the latest official upstream best
 practices, using the nine `bp-*` specialist subagents in
 `.claude/agents/currency/`, then merge their findings into one prioritized,
 source-cited review document. The skill's sole output is that document —
-`docs/currency-review-YYYY-MM-DD.md`, holding the findings **and a phased plan to
-implement the fixes**; it makes **no other code changes**.
+`docs/<today>-currency-review.md` (use the date printed above), holding the findings
+**and a phased plan to implement the fixes**; it makes **no other code changes**.
 
 This is the upstream-currency lens: *"do the code and our rules still match the
 latest official guidance for the stack?"* Its project-rules counterpart is
 `/review-house`. The `bp-*` agents have web access; the `rv-*` agents do not. Run
-this occasionally (on dependency bumps or periodically), not on every diff. Follow
-the shared orchestration rules in `.claude/REVIEW-CONVENTIONS.md`.
+this occasionally (on dependency bumps or periodically), not on every diff.
+
+## Scope
+`$ARGUMENTS`
+
+If that is non-empty, scope the sweep to it (a module path, "since last release", a
+single domain like "just compose") and pass the scope verbatim into every spawn's
+prompt. If it is empty, review the whole repository.
 
 ## The nine specialists
 1. `bp-kotlin` — Kotlin language + kotlinx.coroutines/Flow idioms
@@ -38,13 +51,15 @@ and synthesize only after all nine return:
 
 ## Findings-discipline rule (end every spawn's prompt with this)
 > Report only **upstream-currency** gaps — where the code diverges from current
-> official best practice for the pinned version. Give severity (Critical /
-> Should-fix / Optional), `file:line`, a concrete fix, and **the source URL + its
-> version/date**. Respect deliberate pinned project decisions; defer
+> official best practice for the pinned version. Read the pins out of
+> `gradle/libs.versions.toml`; never assert a version from memory. Give severity
+> (Critical / Should-fix / Optional), `file:line`, a concrete fix, and **the source
+> URL + its version/date**. Respect deliberate pinned project decisions; defer
 > internal-correctness findings to the matching `rv-*` agent. Do not invent
-> findings if the area is already current.
+> findings if the area is already current. Full contract: the
+> `currency-findings-contract` skill preloaded into your context.
 
-Then **synthesize** the nine reports into `docs/currency-review-YYYY-MM-DD.md` exactly
+Then **synthesize** the nine reports into `docs/<today>-currency-review.md` exactly
 as described in `.claude/REVIEW-CONVENTIONS.md` (*Synthesize — write the review
 document*): a two-part doc with the tiered findings — including a *pinned version vs.
 latest stable* currency table — **and a phased implementation plan** for the fixes

--- a/.claude/skills/review-house/SKILL.md
+++ b/.claude/skills/review-house/SKILL.md
@@ -1,19 +1,32 @@
 ---
 name: review-house
-description: Orchestrate a full house-rules review of the entire project from the eleven rv-* review specialists, dispatched in three parallel waves, then synthesize one prioritized review document written to docs/house-review-YYYY-MM-DD.md (findings + a phased fix plan). Writes only that doc; makes no other code changes (each subagent may persist notes to its own project memory). Do not invoke automatically.
+description: Orchestrate a full house-rules review of the project from the eleven rv-* specialists, dispatched in three parallel waves, then synthesize one prioritized review document under docs/ (findings + a phased fix plan). Writes only that doc. Do not invoke automatically.
 disable-model-invocation: true
-allowed-tools: Read, Grep, Glob, Bash, Agent, Write
+argument-hint: "[optional scope, e.g. 'core:data' | 'since last release' | 'just compose']"
+allowed-tools: Read, Grep, Glob, Bash(git ls-files*), Bash(git status*), Bash(git log*), Bash(git diff*), Agent, Write
 ---
+
+## Today
+!`date +%F`
+
+**First, read `${CLAUDE_PROJECT_DIR}/.claude/REVIEW-CONVENTIONS.md`** — it carries the
+shared scope, wave, synthesis and next-step rules this skill depends on.
 
 Run a full-codebase **house-rules** review using the eleven `rv-*` specialist
 subagents in `.claude/agents/review/`, then merge their findings into one
 prioritized review document. The skill's sole output is that document —
-`docs/house-review-YYYY-MM-DD.md`, holding the findings **and a phased plan to
-implement the fixes**; it makes **no other code changes**.
+`docs/<today>-house-review.md` (use the date printed above), holding the findings
+**and a phased plan to implement the fixes**; it makes **no other code changes**.
 
 This is the project-rules lens: *"does the code obey this project's own rules?"* Its
-upstream-currency counterpart is `/review-currency`. Follow the shared orchestration
-rules in `.claude/REVIEW-CONVENTIONS.md` (waves, scope, synthesize, next steps).
+upstream-currency counterpart is `/review-currency`.
+
+## Scope
+`$ARGUMENTS`
+
+If that is non-empty, scope the sweep to it (a module path, "since last release", a
+single domain like "just compose") and pass the scope verbatim into every spawn's
+prompt. If it is empty, review the whole repository.
 
 ## The eleven specialists
 1. `rv-arch` — module layering, dependency direction, API/impl split
@@ -40,7 +53,7 @@ in a single message carrying the scope, and synthesize only after all eleven ret
 > severity (Critical / Should-fix / Optional), `file:line`, and a concrete fix. Do
 > not invent findings if the area is sound.
 
-Then **synthesize** the eleven reports into `docs/house-review-YYYY-MM-DD.md` exactly
+Then **synthesize** the eleven reports into `docs/<today>-house-review.md` exactly
 as described in `.claude/REVIEW-CONVENTIONS.md` (*Synthesize — write the review
 document*): a two-part doc with the tiered findings **and a phased implementation plan**
 for the fixes (phases ordered by risk/value, each committable, with files + a `./gradlew`


### PR DESCRIPTION
An audit of `/review-currency` and its nine `bp-*` specialists against the current official [subagent](https://code.claude.com/docs/en/sub-agents) and [skill](https://code.claude.com/docs/en/skills) authoring guidance. The *form* was already compliant — every frontmatter field in use is supported, and the orchestrator/specialist split, family subfolders and ownership matrix all match documented practice. The *content* had rotted.

## The core problem: a currency auditor with a stale baseline

The specialists hardcoded the stack's version pins in their own prompts. Ten weeks on, those copies had drifted:

| Component | Actual | Agent asserted |
|---|---|---|
| Compose MP | 1.12.0 | 1.11.1 (`bp-compose`, `bp-testing`) |
| Navigation 3 | 1.1.7 runtime / 1.1.1 ui | 1.1.3, as a single pin (`bp-compose`) |
| material3 | 1.12.0-alpha03 | 1.11.0-alpha07 (`bp-compose`) |
| Room | 3.0.2 | 3.0.0-rc01 (`bp-room`) |

`bp-compose`'s "don't flag the material3 alpha" guard named a version that no longer exists, so it could have flagged the current pin as outdated — the exact churn it was written to prevent. Notably `bp-gradle` and `bp-android`, the two agents that *derive* their versions from the repo, had not drifted at all.

Every agent now names the catalog key instead of the number. `bp-compose` also distinguishes the two navigation3 refs, and states the material3 alignment as a rule rather than a number.

## Two stale project facts

- **`bp-koin`** claimed the project "relies on compile-time validation rather than runtime `verify()` in tests". It has both, and the `verify()` tests are load-bearing — the compiler plugin only validates at the `@KoinApplication` entry points. An agent told the opposite could have proposed deleting them. It now covers both layers, `settingsNavigationModule`, and the deliberate choices it must not churn against.
- **`bp-ci`** named `rv-build` as its pair; `rv-ci` has existed since June and the ownership matrix pairs them. The stale reference silently broke the cross-lens de-duplication rule.

## Read-only was prose, not policy

`memory: project` makes the harness grant `Write`/`Edit` even though `tools:` omits them — otherwise the agent could not persist memory. Nothing stopped a specialist from editing source. All twenty agents now carry a `PreToolUse` hook (`.claude/hooks/guard-agent-memory-writes.sh`) that allows writes under `.claude/agent-memory/` and blocks everything else with a reason telling the agent to report the change as a finding.

It lives in **agent frontmatter, not `settings.json`**, so it is scoped to a running review subagent and never constrains a normal session. `disallowedTools: Write, Edit` would have broken memory persistence instead. The script is POSIX `sh` with no `jq` dependency (not guaranteed on Git Bash, the default hook shell on Windows) and was verified against seven payload shapes: Windows-absolute, POSIX-absolute and relative memory paths allow; source file, skill file, missing `file_path`, and a decoy `"file_path"` inside a `content` payload all block.

## Skill and roster hygiene

- `allowed-tools` no longer blanket-pre-approves bare `Bash` (arbitrary shell, no prompt) — narrowed to the `git` subcommands actually used.
- Added `argument-hint` and a `## Scope` section, so the documented scoping arguments are discoverable and actually reach the spawns.
- The review date is now injected rather than inferred, and the output document is named date-first (`docs/<date>-currency-review.md`) to match the `YYYY-MM-DD-<topic>.md` convention the recent `docs/` files use.
- Agent `description`s — which load at every session start — trimmed to the 220–260 char band; sources and checklists belong in the body, which loads only when the agent runs.
- `bp-room` extended to cover `core:datastore`, which had no currency owner.
- The nine near-identical currency reporting blocks became one `currency-findings-contract` skill, preloaded via each agent's `skills:` field, with a fallback pointer in each body. The `rv-*` reporting rules are genuinely per-domain and stay inline.

## Preventing the next drift

`.claude/agents/README.md` now carries two standing rules: read-only is enforced rather than asked for, and **never hardcode what you can read from the repo**. The second is the actual fix — the version re-syncs are treating a symptom.

## Verification

No build impact; `.claude/` is tooling config, not compiled code. Checked: no stale version literal left in any agent or skill; hook and `model` present in 20/20 agents, contract preloaded in 9/9 `bp-*`; no unrestricted `Bash` pre-approval; every frontmatter block well-formed with no duplicate keys; hook re-tested after all edits.

Note that agent-level hooks require trusting the folder containing the agent file — if the guard ever appears not to fire, that is the first thing to check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CnPG14rT7b66gYbsSCprEi