### PR TITLE
chore(claude): audit stale agent memory and pin .claude to LF

### DIFF
--- a/.claude/agent-memory/bp-compose/MEMORY.md
+++ b/.claude/agent-memory/bp-compose/MEMORY.md
@@ -1,3 +1,3 @@
 # Memory Index
 
-- [Compose/nav3 currency baseline](currency-baseline.md) — verified current as of 2026-07-16 for CMP 1.11.1 / nav3 runtime 1.1.4 + ui 1.1.1 (incl. multi-backstack shell)
+- [Compose/nav3 currency baseline](currency-baseline.md) — re-verified 2026-09-06 for CMP 1.12.0 / nav3 runtime 1.1.7 + ui 1.1.1 / material3 1.12.0-alpha03; corrects two wrong entries (core:model IS unstable; the multi-backstack recipe now uses rememberSerializable) and lists two graduated opt-ins to flag

--- a/.claude/agent-memory/bp-compose/currency-baseline.md
+++ b/.claude/agent-memory/bp-compose/currency-baseline.md
@@ -1,68 +1,117 @@
 ---
 name: currency-baseline
-description: Upstream-currency verification of kmp-ledger Compose UI + Navigation 3 against pinned CMP 1.11.1 / nav3 runtime 1.1.4 + ui 1.1.1, last re-checked 2026-07-16
+description: Upstream-currency verification of kmp-ledger Compose UI + Navigation 3 against pinned CMP 1.12.0 / nav3 runtime 1.1.7 + ui 1.1.1 / material3 1.12.0-alpha03, last re-checked 2026-09-06
 metadata:
   type: project
 ---
 
-Upstream-currency audit result (re-verified 2026-07-16; prior passes 2026-07-02,
-2026-06-26): the Compose + Navigation 3 surface is CURRENT for the pinned
-versions. UI code is materially unchanged across these passes.
+Upstream-currency audit result, re-verified 2026-09-06 (prior passes 2026-07-16,
+2026-07-02, 2026-06-26). **Read the pins from `gradle/libs.versions.toml` before
+using anything below** — every version named here is a snapshot of what was pinned
+on the date of the pass, not a constant.
 
-**Version delta as of 2026-07-16:** project now pins navigation3-runtime 1.1.4
-(Google `androidx.navigation3`) + navigation3-ui 1.1.1 (JetBrains
-`org.jetbrains.androidx.navigation3`, CMP-aligned — treat like the material3
-alpha pin, not a gap). CMP still 1.11.1 (latest stable; 1.12.0-alpha02 out
-2026-06-16). lifecycle bumped to 2.11.0-rc01. These bumps land squarely on the
-API surface already verified below — no code changes were required or observed.
+**Baseline on 2026-09-06:** CMP 1.12.0 (released 2026-08-26, latest stable),
+navigation3-runtime 1.1.7, navigation3-ui 1.1.1 (JetBrains), material3
+1.12.0-alpha03, adaptive 1.3.0-beta02, lifecycle 2.11.0, material-icons 1.7.3.
+The material3 and adaptive alphas are the exact coordinates the CMP 1.12.0
+Dependencies table declares — verified still aligned; treat as deliberate pins,
+never as staleness.
 
-**Navigation 3 (pinned runtime 1.1.4, released 2026-07-01, bug-fixes only):**
-- Multi-back-stack shell (App.kt, added commit aad1d23 2026-06-29) matches the
-  official recipe developer.android.com/guide/navigation/navigation-3/recipes/multiple-backstacks
-  (page updated 2026-03-16) point for point: per-section `rememberNavBackStack`,
-  SEPARATE decorator instances per stack via `rememberDecoratedNavEntries`,
-  exit-through-home concatenation, entries-overload `NavDisplay`. App even goes
-  beyond the recipe (adds per-stack `rememberViewModelStoreNavEntryDecorator`,
-  remembers the combined entries list). Do NOT flag the unremembered
-  `associateWith` maps — values are stable remembered instances; recipe does the
-  same; allocation churn is rv-perf's lane.
-- `rememberNavBackStack(SavedStateConfiguration, vararg)` (since 1.0.0-alpha08),
-  `rememberDecoratedNavEntries` (alpha09), entries-overload NavDisplay (alpha10)
-  all exist in 1.1.x — confirmed via release notes.
-- `NavDisplay.onBack` is `() -> Unit` (called N times for N pops). App.kt correct.
-- Decorator order: SaveableStateHolder decorator MUST be first — App.kt correct.
-- `rememberSceneSetupNavEntryDecorator` removed from public API in 1.0.0-alpha11;
-  auto-included. Do NOT flag its absence.
-- `sceneStrategies` takes `List<SceneStrategy>`; remembered list — correct.
-- `ListDetailSceneStrategy.listPane()/detailPane()` metadata in PostingModule /
-  navigation<> DSL entries — current API shape.
-- NEWER-STABLE watch: nav3 1.1.4 (2026-07-01) is a bug-fix patch — safe optional
-  bump. 1.2.0-alpha line (alpha05 2026-07-01) adds NavigationBackHandler,
-  deep links, ResultEventBus; breaking DeepLinkRequest changes in alpha05.
-  Revisit only if project bumps off 1.1.x.
+## Two corrections to earlier passes — do not restore the old claims
 
-**Compose MP (1.11.1, released 2026-06-02 — still latest stable as of 2026-07-02):**
-- All screens use `collectAsStateWithLifecycle()`; theme flow collected with
-  `initialValue = ThemeMode.SYSTEM` on a `remember(getThemeMode)`-ed cold flow — current.
-- LazyColumn `items(key = { it.id })`; method-ref callbacks; strong skipping
-  (Kotlin 2.4) memoizes the loop lambdas in NavigationSuiteScaffold items and
-  ThemeModeRow — no stability gaps.
-- `staticCompositionLocalOf` for LocalNavigator — correct.
-- No `derivedStateOf` and none warranted; `remember(keys)` for displayedEntries
-  is the documented choice (state change should recompose).
-- `Icons.AutoMirrored.Filled.ArrowBack` — current (plain ArrowBack deprecated).
-- Compose resources via `org.jetbrains.compose.resources.stringResource` in
-  composition; snackbar messages resolved in composition then captured into
-  LaunchedEffect — matches docs pattern.
-- `currentTopLevel` is plain `remember { mutableStateOf }` not rememberSaveable —
-  DELIBERATE, documented in App.kt comment (section stacks are restored; only
-  selected tab resets). Recipe does the same. Do not flag.
+- **"No stability gaps" was WRONG.** `core/model/build.gradle.kts` applies only
+  `ledger.kotlin.multiplatform` — no Compose compiler — so `Posting` / `NewPosting`
+  are **unstable** to the Compose compiler, and that propagates to
+  `PostingListUiState.Success(List<Posting>)` (`PostingListViewModel.kt:24`),
+  `PostingDetailsUiState.Success(Posting)` (`PostingDetailsViewModel.kt:27`) and
+  `PostingListItem(posting:)` (`PostingListScreen.kt:116`). Strong skipping compares
+  unstable params by `===`, and the Room flow re-allocates every `Posting` on any
+  write, so `===` never holds. The repo has **no** `@Stable`/`@Immutable` anywhere and
+  **no** `stabilityConfigurationFile` (grep-verified 2026-09-06). Report as Should-fix.
+  Fix options, in the order that fits this project's layering: a
+  `stabilityConfigurationFile` naming `app.oreshkov.ledger.core.model.**` wired in
+  `ledger.kotlin.multiplatform.koin.compose.gradle.kts`; or Compose-runtime +
+  `@Immutable` on the model types; or `@Immutable` on the three UI-state classes.
+  Verify with the existing `-Pledger.composeCompilerReports=true` switch. Quantifying
+  the runtime cost is rv-perf's lane. Source:
+  developer.android.com/develop/ui/compose/performance/stability/fix (2026-06-13).
+- **"`currentTopLevel` plain `remember` — recipe does the same" is NO LONGER TRUE, but
+  the replacement API shape is UNVERIFIED.** The behaviour gap is real: each section's
+  stack is restored via `rememberNavBackStack(savedStateConfiguration, root)`
+  (`App.kt:74-76`), so after process death the user returns to a fully-restored *start*
+  section with their selected tab lost. The in-code comment at `App.kt:78-80` justifies
+  the plain `remember` by appeal to the upstream recipe, and that appeal no longer holds.
+  **However** — corrected 2026-09-06 against the pinned artifacts — the snippet this note
+  previously recommended,
+  `rememberSerializable(..., serializer = MutableStateSerializer(NavKeySerializer()))`,
+  does **not** resolve on these pins: `androidx.navigation3:navigation3-runtime:1.1.7`
+  ships only `NavBackStackSerializer`/`NavBackStackSerializerKt` in
+  `androidx.navigation3.runtime.serialization` — there is **no `NavKeySerializer`**.
+  `MutableStateSerializer` does exist (`androidx.savedstate:savedstate-compose:1.4.0`,
+  resolved transitively), but `rememberSerializable` was not located on the pinned
+  classpath. Do not propose that snippet without first confirming which serializer shape
+  1.1.7 actually offers.
+  The portable fix that needs no serializer plumbing: persist the selected section as an
+  `Int` index into `sectionRoots` with `rememberSaveable`, deriving the `NavKey` from it.
+  Raise as a note for the user's call — whether losing the tab is acceptable UX is a
+  product decision, and the state-holder wiring itself is rv-compose's lane.
 
-**Deferred (out of bp-compose lane):** LaunchedEffect-on-boolean snackbar
-pattern in PostingEditScreen.kt and SettingsScreen.kt — event-modeling
-correctness owned by rv-compose, not an upstream-deprecated pattern.
+## Stale opt-ins to flag (both graduated upstream)
 
-**Sources:** developer.android.com/jetpack/androidx/releases/navigation3;
-developer.android.com/guide/navigation/navigation-3/recipes/multiple-backstacks
-(2026-03-16); developer.android.com/guide/navigation/navigation-3/save-state;
-kotlinlang.org/docs/multiplatform/whats-new-compose-111.html.
+- `App.kt:11,41` — `ExperimentalMaterial3AdaptiveNavigationSuiteApi` no longer
+  annotates any declaration in material3-adaptive-navigation-suite 1.12.0-alpha03;
+  the marker class is a leftover. Removable. Keep `ExperimentalMaterial3AdaptiveApi`
+  — `rememberListDetailSceneStrategy` and the `ListDetailSceneStrategy` companion
+  are still experimental in adaptive 1.3.0-beta02.
+- `@OptIn(ExperimentalMaterial3Api::class)` on all four screens
+  (`PostingListScreen.kt:57`, `PostingEditScreen.kt:77`, `PostingDetailsScreen.kt:87`,
+  `SettingsScreen.kt:72`) — the only experimental API they used was `TopAppBar`, which
+  graduated in Jetpack Material3 1.5.0-alpha22 (2026-06-17), the release CMP's
+  1.12.0-alpha03 is based on. Removable.
+
+## Navigation 3 — verified current for the pinned 1.1.x
+
+- The `NavDisplay(entries, …, sceneStrategies: List<SceneStrategy<T>>, …, onBack: () -> Unit)`
+  overload `App.kt` binds to is **not** deprecated; the two `@Deprecated` overloads are
+  `DeprecationLevel.HIDDEN` singular-`sceneStrategy` forms the project already avoids.
+  nav3-runtime commonMain contains zero `@Deprecated` declarations.
+- Multi-back-stack shell matches the recipe point for point apart from the
+  `rememberSerializable` item above: per-section `rememberNavBackStack`, one
+  `rememberSaveableStateHolderNavEntryDecorator` per stack (SaveableStateHolder first),
+  `rememberDecoratedNavEntries` per stack, exit-through-home concatenation.
+- `onBack` is `() -> Unit` in 1.1.x. The `onBackCompleted`/`onBackCancelled` split,
+  `NavigationBackHandler` and the reshaped `DeepLinkRequest` are **1.2.0 only**.
+- `NavigationSuiteScaffold` — `App.kt:123` binds the current `state`-carrying overload;
+  the state-less ones are `DeprecationLevel.HIDDEN`.
+- Do NOT flag the unremembered `associateWith` maps in `App.kt:74,98-110` — allocation
+  churn is rv-perf's lane, and the recipe allocates the same way.
+- **Alignment watch:** the CMP 1.12.0 Dependencies table names navigation3
+  **1.2.0-alpha02**, while the catalog pins ui 1.1.1. Not a gap today — CMP's own
+  `adaptive-navigation3:1.3.0-beta02` resolves navigation3-ui 1.1.0, 1.1.1 is the
+  latest *stable*, and 1.2.0 is source-breaking. Re-evaluate when nav3-ui 1.2.0 ships
+  stable or the next CMP bump forces it.
+
+## Verified current — do not re-litigate
+
+`collectAsStateWithLifecycle` everywhere (no bare `collectAsState`); theme flow
+remembered on the use case then collected with `initialValue`; no
+`LaunchedEffect(Unit)`/`(true)`; `staticCompositionLocalOf` for `LocalNavigator` with
+the trade-off documented; every `Res`-generating module pins `packageOfResClass` and
+only `core:compose` sets `publicResClass = true`; `Icons.AutoMirrored` for mirroring
+glyphs; no CMP 1.12.0 deprecations hit (no `NativeCanvas`/`NativePaint`, no `SwingPanel`
+background param) and `desktopApp` already on the `ui.window.v2` API.
+
+**Deferred (out of bp-compose's lane):** `LaunchedEffect`-on-boolean snackbar
+signalling and lifecycle-unaware `Channel` event collection → rv-compose;
+allocation churn in `App.kt` → rv-perf.
+
+**Why:** this file exists to stop re-deriving the same verdicts every pass — which
+makes a wrong entry expensive: the two corrections above each suppressed a real
+finding for multiple passes. An entry that says "do not flag X" must carry the
+evidence that justified it and the date, so the next pass can tell a settled fact
+from an expired one.
+
+**How to apply:** re-read the pins first; anything above whose version moved is
+unverified until re-checked against the pinned artifact's own sources (the Gradle
+cache's `-sources.jar` is stronger evidence than a release note). Prefer correcting
+an entry in place over appending a newer contradictory one.

--- a/.claude/agent-memory/bp-gradle/MEMORY.md
+++ b/.claude/agent-memory/bp-gradle/MEMORY.md
@@ -1,4 +1,4 @@
 # Memory Index
 
-- [Gradle currency baseline](gradle-currency-baseline.md) — what's already current in the Gradle build; don't re-flag these
-- [Deliberate Gradle divergences](deliberate-gradle-divergences.md) — intentional choices to respect, not report as gaps
+- [Gradle currency baseline](gradle-currency-baseline.md) — durable structural verdicts, the `--warning-mode all` empirical check, and dated version observations to re-derive each run
+- [Deliberate Gradle divergences](deliberate-gradle-divergences.md) — intentional choices to respect; states rules not numbers; records the AGP pin's Gradle 10 expiry

--- a/.claude/agent-memory/bp-gradle/deliberate-gradle-divergences.md
+++ b/.claude/agent-memory/bp-gradle/deliberate-gradle-divergences.md
@@ -1,16 +1,50 @@
 ---
 name: deliberate-gradle-divergences
-description: Intentional Gradle choices in kmp-ledger to respect — do not report as currency gaps
+description: Intentional Gradle choices in kmp-ledger to respect — do not report as currency gaps. States the rules, not version numbers
 metadata:
   type: project
 ---
 
-Deliberate, documented divergences from generic upstream guidance. Respect these; at most mention as "intentional" — never raise as Should-fix.
+Deliberate, documented divergences from generic upstream guidance. Respect these; at most
+mention as "intentional" — never raise as Should-fix.
 
-- **Explicit per-target `jvmTarget = JVM_21` instead of `jvmToolchain(21)`/Java toolchain.** Set on base plugin `jvm()`, `androidApp`, `desktopApp`. Reproducibility comes from the daemon being pinned to JDK 21 (`gradle/gradle-daemon-jvm.properties` → `toolchainVersion=21`) + CI Temurin 21. Decision recorded in `docs/full-review-2026-06-23.md` (C1/S1) and rv-build memory `jvm-target-config.md`. 21 is a hard ceiling (daemon JDK).
-- **material3 pinned to `1.11.0-alpha07`** — aligned with Compose MP 1.11.1, not a stale pin. See user memory `material3-version-pin`.
-- **Kover floors** (aggregate 88/60/84 + per-module) are a deliberate policy; branch floor kept modest for Compose synthetic branches. See user memory `kover-coverage-policy`.
-- **Room destructive fallback** (`fallbackToDestructiveMigration(dropAllTables=true)`) is an intentional pre-release posture, not an oversight.
+- **Explicit per-target `jvmTarget = JVM_21` instead of `jvmToolchain(21)`/Java toolchain.**
+  Set on base plugin `jvm()`, `androidApp`, `desktopApp`. Reproducibility comes from the
+  daemon being pinned to JDK 21 (`gradle/gradle-daemon-jvm.properties` →
+  `toolchainVersion=21`) plus CI Temurin 21. Decision recorded in
+  `docs/full-review-2026-06-23.md` (C1/S1) and rv-build memory [[jvm-target-config]]. 21 is
+  a hard ceiling (daemon JDK).
+- **material3 and adaptive are pinned to prerelease versions on purpose.** The rule, not
+  the number: they must be *the exact coordinates Compose Multiplatform declares alignment
+  with* in its release-notes Dependencies table. Read `androidx-material3` and
+  `androidx-adaptive` from `gradle/libs.versions.toml` and check them against the table for
+  the pinned `compose-multiplatform`. A pin that matches the table is correct even when it
+  looks like an old alpha; a pin that no longer matches is a real finding. See user memory
+  `material3-version-pin`.
+  *(Corrected 2026-09-06: this bullet used to hardcode "material3 1.11.0-alpha07, aligned
+  with CMP 1.11.1" — both had moved, so the note would have vouched for a pin the project
+  no longer has.)*
+- **Kover floors** (aggregate + per-module) are a deliberate policy; the branch floor is
+  kept modest for Compose synthetic branches. See user memory `kover-coverage-policy`.
+- **Room destructive fallback** (`fallbackToDestructiveMigration(dropAllTables=true)`) is
+  an intentional pre-release posture, not an oversight.
+- **AGP is pinned below latest on purpose** — to the ceiling the user's bundled IntelliJ
+  IDEA plugin supports; the catalog carries the reason and an inspection suppression on the
+  line. Read the pin rather than naming a number here. Details in
+  [[gradle-currency-baseline]].
+  *(Added 2026-09-06: this pin now has an expiry. The pinned AGP's internal plugins
+  (`com.android.internal.application`, `com.android.internal.kotlin.multiplatform.library`)
+  pass a `Project` object as dependency notation — deprecated in Gradle 9.6, a hard **error
+  in Gradle 10**. Nothing in this repo's build scripts triggers it, so there is no code fix;
+  the pin stays deliberate. But the project cannot move to Gradle 10 until AGP is bumped
+  past it. Verify with `./gradlew help --warning-mode all` and read the `pluginId` fields in
+  `build/reports/problems/problems-report.html`.)*
 
-**Why:** These were chosen with reasons; re-raising them wastes the user's time and contradicts prior review conclusions.
-**How to apply:** If an audit surfaces one of these, note it's intentional and move on. Owner of toolchain/target internal correctness is the rv-build agent.
+**Why:** these were chosen with reasons; re-raising them wastes the user's time and
+contradicts prior review conclusions. But a divergence is only "deliberate" while its
+*reason* holds — an alignment pin whose upstream alignment moved is no longer the
+decision the project made.
+
+**How to apply:** if an audit surfaces one of these, check the stated reason still holds,
+note it is intentional, and move on. Never restate a version number here that can be read
+from the catalog. Owner of toolchain/target internal correctness is the rv-build agent.

--- a/.claude/agent-memory/bp-gradle/gradle-currency-baseline.md
+++ b/.claude/agent-memory/bp-gradle/gradle-currency-baseline.md
@@ -1,33 +1,111 @@
 ---
 name: gradle-currency-baseline
-description: Gradle build areas already matching current best practice — don't re-raise these as findings
+description: Gradle build areas already matching current best practice — don't re-raise these. Structural verdicts durable; version claims are dated observations, re-derive every run
 metadata:
   type: project
 ---
 
-State of the kmp-ledger Gradle build vs upstream best practice (re-verified 2026-07-16 against docs.gradle.org for Gradle 9.6.1; prior pass 2026-07-02).
+State of the kmp-ledger Gradle build vs upstream best practice. Structure re-verified
+2026-09-06 against docs.gradle.org 9.7.1; prior passes 2026-07-16, 2026-07-02.
 
-**Already current — do not re-flag:**
-- Wrapper `gradle-9.6.1-bin.zip` = latest stable (released 2026-06-26). Re-check `gradle/wrapper/gradle-wrapper.properties` against gradle.org/releases each audit.
-- Toolchain versions current stable as of 2026-07-02: Kotlin 2.4.0, Kover 0.9.8 (Mar 2026), Compose MP 1.11.1.
-- AGP is **deliberately pinned to 9.1.0** (changed 2026-07-19, was 9.2.1) — NOT the latest AGP (9.3.0). Reason: IntelliJ IDEA's bundled Android plugin lags the AGP release train (and lags Android Studio), and the user's latest IDEA caps at AGP 9.1.0; 9.2.1 made IDEA refuse to sync ("incompatible version … Latest supported version is AGP 9.1.0"). Pinning to the IDEA ceiling keeps the project openable in both IDEA and Android Studio with no per-machine IDE flags. **Do not flag AGP as behind latest** — bump only after IDEA raises its ceiling (track JetBrains IDEA-385007). Gradle 9.6.1 already exceeds the min for AGP 9.1/9.2/9.3, so a later AGP bump won't need a Gradle change.
-- `build-logic/` uses precompiled script plugins (`kotlin-dsl`), `compileOnly` plugin deps, three composable `ledger.kotlin.multiplatform[.koin][.compose]` plugins. Matches "Sharing build logic with convention plugins". No `subprojects {}`/`allprojects {}`, no `afterEvaluate`, no eager `tasks.create` anywhere.
-- Lazy APIs: `composeCompiler` reads `providers.gradleProperty(...)`; androidApp version code/name via `providers.gradleProperty`; signing secrets via `providers.environmentVariable` (commit 9e0c19b). The old `project.property(...)` nit is fixed.
-- Configuration cache + build cache + `org.gradle.parallel=true` all set in `gradle.properties`. CC `problems` left at default `fail` (correct for a CC-clean build — don't suggest `warn`). `org.gradle.configuration-cache.parallel` is still incubating in 9.6.1 — at most Optional, with the "some builds may not work" caveat.
-- Version catalog: version.ref everywhere, plugin aliases via `alias(libs.plugins.*)`, `common-test` bundle declared AND consumed (core:common/domain/database/data/datastore). No hardcoded versions.
-- Daemon JVM pinned via `gradle/gradle-daemon-jvm.properties` (toolchainVersion=21 + foojay toolchainUrl entries from `updateDaemonJvm`) — this is the current recommended daemon-JVM provisioning.
-- Repositories centralized in settings (`dependencyResolutionManagement`), google() content-filtered; `rootProject.name` set in both settings files.
+**Read every version from `gradle/libs.versions.toml` and
+`gradle/wrapper/gradle-wrapper.properties` before judging anything.** Numbers written
+below are dated observations, not current facts.
 
-**Resolved since 2026-07-02 (do not re-flag):**
-- `distributionSha256Sum` IS now present in gradle-wrapper.properties (line 3) — wrapper checksum verification done.
-- `RepositoriesMode.FAIL_ON_PROJECT_REPOS` IS now enforced in settings.gradle.kts:19.
+## Already current — do not re-flag (structural, durable)
 
-**Standing Optional items (raise only as Optional, never higher):**
-- No `gradle/verification-metadata.xml` (dependency verification).
-- `org.gradle.tooling.parallel=true` (gradle.properties:23) is a REAL documented property since Gradle 9.4.0 (parallel Tooling API / IDE sync). Comment is accurate — do not flag.
-- BCV: project uses standalone `binary-compatibility-validator` 0.18.1 (deliberate pin). Kotlin 2.2+ ships a built-in KGP `abiValidation {}` DSL intended to replace it, but it is still `@ExperimentalAbiValidation` in Kotlin 2.4 and the standalone plugin is NOT yet officially deprecated (deprecation follows stabilization, KT-71172). Staying on standalone is current-appropriate; migration is informational only.
+- `build-logic/` uses precompiled script plugins (`kotlin-dsl`), `compileOnly` plugin deps,
+  and three composable `ledger.kotlin.multiplatform[.koin][.compose]` plugins. Matches
+  "Sharing build logic with convention plugins" and "Favor `build-logic` composite builds".
+  No `subprojects {}`/`allprojects {}`, no `afterEvaluate`, no eager `tasks.create` anywhere
+  in the repo.
+- Lazy APIs: `composeCompiler` reads `providers.gradleProperty(...)`; androidApp version
+  code/name via `providers.gradleProperty`; signing secrets via
+  `providers.environmentVariable`. The remaining `.get()` calls (androidApp:27,31-34,
+  desktopApp:76) feed *non-lazy* DSL properties (`compileSdk: Int`, `versionCode: Int`,
+  `packageVersion: String`) — the tasks best practice "don't call `get()` outside a task
+  action" does not apply there. **Do not flag these.**
+- Configuration cache + build cache + `org.gradle.parallel=true` set in `gradle.properties`.
+  CC `problems` left at default `fail` (correct for a CC-clean build — never suggest `warn`;
+  the docs call `warn` a migration aid only).
+- Version catalog: `version.ref` everywhere, plugin aliases via `alias(libs.plugins.*)`,
+  `-plugin` suffix on plugin libraries, `common-test` bundle declared AND consumed. No
+  hardcoded versions anywhere in `*.gradle.kts` (grep for `"\d+\.\d+\.\d+"` returns none).
+- No `gradle.properties` in any subproject (matches the general best practice).
+- Daemon JVM pinned via `gradle/gradle-daemon-jvm.properties` (`toolchainVersion=21` plus
+  foojay `toolchainUrl` entries from `updateDaemonJvm`) — current recommended daemon-JVM
+  provisioning. No toolchain resolver plugin needed.
+- Repositories centralized in root settings (`dependencyResolutionManagement`), `google()`
+  content-filtered, `RepositoriesMode.FAIL_ON_PROJECT_REPOS` enforced, `rootProject.name`
+  set in both settings files. **Exception:** `build-logic/settings.gradle.kts` does *not*
+  content-filter its `google()` — raised 2026-09-06 as Optional.
+- `distributionSha256Sum` present in gradle-wrapper.properties; `-bin` distribution used.
+  Both match the security/performance best practices — do not re-flag.
+- `core/database` already uses target-specific KSP configurations (`kspAndroid`, `kspJvm`,
+  `kspIosArm64`, `kspIosSimulatorArm64`), which is what KSP 2.3.10 deprecated the plain
+  `ksp(...)` configuration in favour of. No migration owed.
 
-**Why:** Avoids spending audit budget re-deriving the same green areas every run.
-**How to apply:** On the next currency pass, confirm these are unchanged and move on; respect [[deliberate-gradle-divergences]].
+## Verified empirically 2026-09-06 — the cheap check that pays
 
-Internal-correctness items (defer to rv-build): duplicated Kover exclude lists between root `build.gradle.kts` and the base convention plugin.
+`./gradlew help --warning-mode all --console=plain` then read
+`build/reports/problems/problems-report.html`. On that date: **5 problems, all one
+deprecation, all attributed to AGP internal plugin IDs** (`com.android.internal.application`,
+`com.android.internal.kotlin.multiplatform.library`) — zero from KGP, zero from project
+build scripts, CC entry stored cleanly. Re-run this before asserting the build is
+deprecation-clean; the problems report carries `pluginId` attribution, which is what tells
+you whether a warning is yours or a plugin's.
+
+## Resolved 2026-09-06 — the Kotlin/Gradle matrix overrun is NOT a finding
+
+Kotlin's own table (kotlinlang.org "Configure a Gradle project") gives KGP 2.4.0–2.4.10 a
+fully-supported Gradle range of 7.6.3–9.5.0 and AGP 8.5.2–9.1.0, then says verbatim: "You
+can also use Gradle and AGP versions up to the latest releases, but if you do, keep in mind
+that you might encounter deprecation warnings or some new features might not work."
+Counter-evidence from the Gradle side (docs.gradle.org/9.7.1 compatibility matrix): Gradle
+9.7 **embeds Kotlin 2.4.0**, is tested with Kotlin 2.0.0–2.4.20-Beta1 and AGP 9.0–9.4.0-alpha03.
+The empirical check above found zero KGP deprecations. The AGP overrun is a single patch
+inside the same minor line. **Verdict: no action. Do not re-raise this as a finding** —
+re-check only if the empirical run starts showing KGP-sourced warnings.
+
+## Version-dependent claims — re-derive, do not trust
+
+- **Wrapper vs latest.** On 2026-09-06 the wrapper pinned **9.6.1** while latest stable was
+  **9.7.1** (2026-08-19; 9.7.0 was 2026-08-06). Gradle's general best practice is "Use the
+  Latest Minor Version of Gradle". Re-check gradle.org/releases every run.
+- **AGP is deliberately pinned below latest** to the user's IntelliJ IDEA plugin ceiling —
+  see [[deliberate-gradle-divergences]], which now also records the Gradle 10 expiry this
+  pin acquired. Do not flag AGP as behind latest.
+- **Pins that were AT latest on 2026-09-06** (so a bump report is wrong unless upstream
+  moved): Kover 0.9.9 (0.9.9 itself is the release that fixed Gradle 9.6 deprecation
+  warnings), BCV 0.18.2, compose-hot-reload 1.2.0 (1.3.0-alpha01 exists — prerelease, not a
+  gap). KSP was **behind**: pinned 2.3.9, latest 2.3.11.
+- **BCV**: the standalone `binary-compatibility-validator` plugin is a deliberate pin.
+  Kotlin's built-in KGP `abiValidation {}` DSL is intended to replace it but was still
+  `@ExperimentalAbiValidation` in Kotlin 2.4, and the standalone plugin is NOT deprecated
+  (deprecation follows stabilization, KT-71172). Staying on standalone is correct;
+  migration is informational only.
+
+## Standing Optional items (raise only as Optional, never higher)
+
+- No `gradle/verification-metadata.xml` (dependency verification). Gradle 9.7.0 added
+  `origin`/`reason` attributes on trusted PGP keys if this is ever adopted.
+- `org.gradle.configuration-cache.parallel` is still **incubating** as of 9.7.1 (docs warn it
+  can cause `ConcurrentModificationException`). Isolated Projects auto-enables parallel CC,
+  so this is mostly subsumed by that migration.
+- `org.gradle.tooling.parallel=true` is a REAL documented property since Gradle 9.4.0
+  (parallel Tooling API / IDE sync). The comment in `gradle.properties` is accurate — do not
+  flag it as invented.
+
+**Why:** avoids spending audit budget re-deriving the same green areas every run — but the
+structural verdicts and the version claims rot at completely different rates, so they are
+kept in separate sections. Mixing them is what let "Kover 0.9.8 is latest" sit under a "do
+not re-flag" heading for seven weeks.
+
+**How to apply:** trust the structural section; re-derive every version claim against the
+pins and gradle.org/releases; run the empirical `--warning-mode all` check before claiming
+deprecation cleanliness; then correct this note in place — writes under
+`.claude/agent-memory/` are permitted. Respect [[deliberate-gradle-divergences]].
+
+Internal-correctness items (defer to rv-build): duplicated Kover exclude lists between root
+`build.gradle.kts` and the base convention plugin; the base plugin's `commonTest` using bare
+`kotlin-test` rather than the `common-test` bundle the modules use.

--- a/.claude/agent-memory/bp-kmp/MEMORY.md
+++ b/.claude/agent-memory/bp-kmp/MEMORY.md
@@ -1,4 +1,4 @@
 # bp-kmp Memory Index
 
-- [KMP structure posture](kmp-structure-posture.md) — targets/hierarchy/expect-actual/swift-export choices that are deliberate and current for Kotlin 2.4.0
+- [KMP structure posture](kmp-structure-posture.md) — targets/hierarchy/expect-actual/swift-export choices that are deliberate; re-verified 2026-09-06 against the pins
 - [iOS findings advisory](ios-findings-advisory.md) — user has no iOS env; frame iOS/Swift-export findings as advisory, not actionable

--- a/.claude/agent-memory/bp-kmp/kmp-structure-posture.md
+++ b/.claude/agent-memory/bp-kmp/kmp-structure-posture.md
@@ -1,18 +1,65 @@
 ---
 name: kmp-structure-posture
-description: kmp-ledger's KMP source-set/target/expect-actual/swift-export/BCV posture and which choices are deliberate-and-current (re-verified 2026-07-16 vs Kotlin 2.4.0 docs)
+description: kmp-ledger's KMP source-set/target/expect-actual/swift-export posture and which choices are deliberate-and-current (re-verified 2026-09-06 against Kotlin 2.4.0 docs + KGP v2.4.0 sources)
 metadata:
   type: project
 ---
 
-kmp-ledger KMP structure is current against JetBrains guidance for the pinned Kotlin 2.4.0 (re-verified 2026-07-16 against live docs; Swift export doc dated 2026-05-29, still Alpha; expect/actual classes still Beta; no drift since 2026-07-02). Durable facts so future audits don't re-derive:
+kmp-ledger KMP structure re-verified 2026-09-06 against the pins read that day
+(`kotlin = 2.4.0`, `kotlinx-binary-compatibility-validator = 0.18.2`). Treat every
+version below as a **dated observation**, not a standing fact — re-read
+`gradle/libs.versions.toml` first on each run.
 
-- **Targets**: `iosArm64()`, `iosSimulatorArm64()`, `jvm()`, plus Android via the **new AGP KMP library plugin** `com.android.kotlin.multiplatform.library` with the `android { }` DSL (configured in convention plugins via `extensions.configure<KotlinMultiplatformAndroidLibraryTarget>("android")`, `withHostTest {}`). Current, not deprecated.
-- **Source-set hierarchy**: relies on the **default hierarchy template** implicitly. No `applyDefaultHierarchyTemplate()` call and no manual `dependsOn` anywhere (grep-verified). `iosMain` is auto-created. Hierarchy doc (2026-03-16) unchanged — do not propose manual wiring.
-- **expect/actual**: `PlatformDatabaseModule` (core:database) AND `PlatformDataStoreModule` (core:datastore) are `expect class`es annotated Koin `@Module`. DELIBERATE and defensible — the class IS the Koin DI module; "replace with interface + DI" guidance doesn't apply. Tracked as advisory O8 in docs/full-review-2026-06-30.md. Other expect: `getPlatformLogWriters()` (fun), `LedgerDatabaseConstructor` (Room expect object), `createTestDatabase()` (fun). `-Xexpect-actual-classes` correctly set in core:database, core:datastore, core:test, androidApp. Expect/actual classes still **Beta** per doc dated 2026-05-13.
-- **Swift export**: **Alpha** in Kotlin 2.4.0 (doc 2026-05-29). `iosExport` uses `swiftExport { moduleName="Ledger"; flattenPackage }` under `@OptIn(ExperimentalSwiftExportDsl::class)` — DSL opt-in still required. Xcode invokes `:iosExport:embedSwiftExportForXcode`. `initializeKoin()` before `MainViewController()` in `iOSApp.init()` — sound. Kotlin 2.4.0 raised min iOS deployment to 15.0; iosApp targets 18.2, fine.
-- **Swift-export dead config (known, Optional)**: (1) `iosExport` also declares `binaries.framework "LedgerBinary"` — never consumed (Xcode only calls embedSwiftExportForXcode); docs confirm no framework needed with Swift export. Tracked as O3 in docs/best-practices-review-2026-06-26-outstanding.md. (2) `core/bootstrap/build.gradle.kts:10-12` has an **inert** `swiftExport { moduleName="Ledger" }` — bootstrap is never a swift-export root and iosExport has no `export(project(":core:bootstrap"))`; per docs dependency export goes via `export()` in the root block. Flagged Optional 2026-07-02. Missing `@OptIn` there is cosmetic (see rv-build memory swift-export-and-catalog-quirks).
-- **BCV**: standalone plugin 0.18.1 = latest release (2025-07-09), with experimental `klib { enabled; strictValidation }`. KGP built-in `abiValidation` is still **Experimental** and JetBrains does not yet recommend it for production; standalone BCV remains maintained. Project posture is current — do not propose migrating to KGP abiValidation until it stabilizes.
+- **Targets**: `iosArm64()`, `iosSimulatorArm64()`, `jvm()`, plus Android via the AGP KMP
+  library plugin `com.android.kotlin.multiplatform.library` with the `android { }` DSL
+  (`extensions.configure<KotlinMultiplatformAndroidLibraryTarget>("android")`,
+  `withHostTest {}`) in `build-logic/src/main/kotlin/ledger.kotlin.multiplatform.gradle.kts`.
+  Current, not deprecated. Grep-verified 2026-09-06: no build script uses any API the
+  Kotlin 2.4.0 compatibility guide removed (`targetHierarchy`, `KotlinTarget.sourceSets`,
+  `compileKotlinTask*`, `enforcedPlatform`/`platform`, `withoutCompilations`,
+  `defaultSourceSetName`, `kotlinArtifacts`, `js(IR|LEGACY)`, native task
+  `languageSettings`/`additionalCompilerOptions`/`konanHome`).
+- **Source-set hierarchy**: relies on the **default hierarchy template** implicitly — no
+  `applyDefaultHierarchyTemplate()` call and no manual `dependsOn` anywhere. That is what
+  the docs prescribe; the explicit call is only needed when adding custom source sets.
+  Hierarchy doc last modified 16 March 2026. Do not propose manual wiring.
+- **expect/actual**: expect/actual **classes are Beta** and `-Xexpect-actual-classes` is
+  still the documented way to silence the warning (expect/actual doc, 13 May 2026). The
+  project sets it in module-level `kotlin { compilerOptions { } }` in core:database,
+  core:datastore, core:test and androidApp — exactly the doc's shape.
+  The doc *does* say "use interfaces where they'd be sufficient", but every expect here
+  survives that test: `PlatformDatabaseModule` / `PlatformDataStoreModule` (the class **is**
+  the Koin `@Module` — deliberate, never flag), `PlatformComposeUiTest` (carries platform
+  `@RunWith(RobolectricTestRunner)`/`@Config` annotations — not expressible as an interface),
+  `getPlatformLogWriters()` and `createTestDatabase()` (expect *functions*, i.e. the doc's
+  own recommended factory shape), `LedgerDatabaseConstructor` (required by Room KMP).
+- **Swift export**: **Alpha** (doc last modified 12 August 2026). `@ExperimentalSwiftExportDsl`
+  **still exists in KGP v2.4.0 sources** (verified via GitHub at tag v2.4.0), so
+  `iosExport/build.gradle.kts`'s `@OptIn(ExperimentalSwiftExportDsl::class)` is correct even
+  though the doc snippet omits it. Xcode run script calls `:iosExport:embedSwiftExportForXcode`
+  (direct integration — the only mode swift export supports). `initializeKoin()` before
+  `MainViewController()` — sound. iOS min deployment rose to 15.0 in 2.4.0; iosApp targets 18.2.
+- **Swift-export gradle property (open finding, 2026-09-06)**: `gradle.properties:24` sets
+  `kotlin.swift-export.experimentalFeature.nowarn=true`, but the property KGP actually reads is
+  **`kotlin.swift-export.experimental.nowarn`** (`PropertiesProvider.kt`, unchanged across
+  v2.2.20 → v2.4.0; it feeds `SwiftExportTask.ignoreExperimentalDiagnostic`). The current name
+  is inert. Note `kotlin.experimental.swift-export.enabled` is separately deprecated and is
+  correctly absent here.
+- **Swift-export dead config (Optional, still present)**: `iosExport/build.gradle.kts` declares
+  `binaries.framework { baseName = "LedgerBinary" }` on both iOS targets; nothing consumes it
+  (Xcode only calls `embedSwiftExportForXcode`) and Kotlin 2.4.0 removed the consumable
+  configurations that exposed Apple frameworks as outgoing artifacts (KT-74503). Tracked as O3
+  in docs/best-practices-review-2026-06-26-outstanding.md.
+  **Corrected 2026-09-06:** the previously noted inert `swiftExport { }` block in
+  `core/bootstrap/build.gradle.kts` is **gone** — that file no longer contains it. Do not
+  re-report it.
+- **BCV**: standalone plugin, pinned 0.18.2, which is the newest release (published 2026-09-02).
+  KGP's built-in `abiValidation` DSL was *simplified* in 2.4.0 (KT-80685: `legacyDump`/`klib`
+  nesting removed) but is still not the recommended replacement; the root `apiValidation { klib { … } }`
+  block is the standalone plugin's own DSL and is unaffected. Rule: match the standalone plugin's
+  newest release, don't migrate to KGP abiValidation until JetBrains marks it stable.
 
 **Why:** avoids re-litigating settled, current choices on each currency audit.
-**How to apply:** treat the above as current best practice; only flag genuine drift from newer docs. See [[ios-findings-advisory]].
+**How to apply:** treat the above as current best practice *as re-derived on 2026-09-06*;
+re-check any "latest"/"still exists" claim against the pins and primary sources before
+reusing it. See [[ios-findings-advisory]].

--- a/.claude/agent-memory/bp-koin/MEMORY.md
+++ b/.claude/agent-memory/bp-koin/MEMORY.md
@@ -1,3 +1,3 @@
 # Memory Index
 
-- [Koin compiler-plugin currency baseline](koin-compiler-plugin-currency.md) — re-verified 2026-07-16: Koin 4.2.2 current; compiler plugin 1.0.2 out (repo pins 1.0.1, one behind); @Provided pinned; verify() justified
+- [Koin compiler-plugin currency baseline](koin-compiler-plugin-currency.md) — re-verified 2026-09-06: pins match latest on both lines; 1.1.0 validation model; @Provided/verify() pinned; annotations DO support @Named multibinding

--- a/.claude/agent-memory/bp-koin/koin-compiler-plugin-currency.md
+++ b/.claude/agent-memory/bp-koin/koin-compiler-plugin-currency.md
@@ -1,22 +1,97 @@
 ---
 name: koin-compiler-plugin-currency
-description: Upstream-currency baseline for kmp-ledger's Koin setup — compiler plugin (not KSP), @Provided is a pinned choice, verify() retention justified here
+description: Upstream-currency baseline for kmp-ledger's Koin setup — compiler plugin (not KSP), @Provided is a pinned choice, verify() retention justified, and the annotation-multibinding correction
 metadata:
   type: reference
 ---
 
-Durable upstream facts for auditing this repo's Koin DI against insert-koin.io. Pinned: Koin 4.2.2, compiler plugin **1.1.0**, Kotlin 2.4.0.
+Durable upstream facts for auditing this repo's Koin DI against insert-koin.io.
+**Read the pins yourself every run** (`gradle/libs.versions.toml`: `koin`, `koin-compiler`, `kotlin`).
+Rule, not numbers: `koin` drives every `io.insert-koin:*` artifact; `koin-compiler` versions
+independently and drives the `io.insert-koin.compiler.plugin` Gradle plugin only.
 
-**Version currency (re-verified 2026-08-01):** Koin core/annotations 4.2.2 is latest stable (docs recommend `version.ref = "koin"` for koin-annotations — repo matches). Compiler plugin **1.1.0 is latest and is what the repo now pins** (upgraded 2026-08-01 from 1.0.2). Plugin releases: github.com/InsertKoinIO/koin-compiler-plugin/releases. Versions to date: 1.0.0 (2026-05-20), 1.0.1 (2026-06-12), 1.0.2 (2026-07-10), 1.1.0. All require Kotlin 2.3.20+ and Koin 4.2.0+ — repo satisfies both.
+**Version currency (re-verified 2026-09-06 against Maven Central metadata, not memory):**
+`koin` runtime line — latest release equals what the repo pins; Central metadata `<lastUpdated>`
+for `io.insert-koin:koin-core` was 2026-06-15. Compiler plugin — latest release equals what the
+repo pins; the plugin marker's `<release>` was published 2026-07-29. Check both here each run:
+- https://repo1.maven.org/maven2/io/insert-koin/koin-core/maven-metadata.xml
+- https://repo1.maven.org/maven2/io/insert-koin/compiler/plugin/io.insert-koin.compiler.plugin.gradle.plugin/maven-metadata.xml
+Plugin release history: 1.0.0 (2026-05-20), 1.0.1 (2026-06-12), 1.0.2 (2026-07-10), 1.1.0 (2026-07-29).
 
-**1.1.0 changed the validation model — the A2/A3/A4 tiering below is partly obsolete.** Per-module (A2) validation was **removed entirely**; the full graph is verified once at each `@KoinApplication` entry point. A module with no entry point in its compilation gets generation only, no diagnostics. So "per-module validation would catch X" is no longer a valid claim about this repo. `KOIN-W002` deleted; `KOIN-W003` (dynamically-computed module set) and `KOIN-D008` (module-id hint-name collision) added — neither fires here. New Gradle knobs: `logSeverity`, `versionCheckSeverity`, `strictSafetyForceOff`; `strictSafety = false` is now ignored once an entry point is detected. Repo sets `logSeverity = "info"` in the koin convention plugin to mute the new per-library-module "compile-safety validation skipped" disclosure.
+**Kotlin compatibility — upstream contradicts itself, so check both.** The plugin README (main)
+says one artifact spans **Kotlin 2.3.20 → 2.4.x**; the 1.1.0 release note's own Compatibility
+section says "verified range 2.3.0–2.3.10". README is the one consistent with 1.0.1's changelog
+(the version-adapter layer). Repo is on Kotlin 2.4.0 and builds. Plugin requires Koin 4.2.0+.
+If the "unverified Kotlin version" warning ever fires, the knob is `versionCheckSeverity` —
+docs say only mute it after assessing the risk yourself, so leaving it at the "warning" default
+(as the repo does) is the correct posture, not a gap.
 
-**Known 1.1.0 bug affecting this repo — don't re-diagnose it.** The full-graph pass ignores the `providerOnly` flag on a DSL `single<T> { … }` whose lambda builds `T`, so it walks `T`'s constructor and reports those params missing. `desktopApp` keeps `compileSafety = false` for this (DesktopUiTest's `RoomDatabase.Builder` override). This is NOT the multi-module false positive 1.0.2/1.1.0 addressed — main source compiles clean. See `docs/2026-08-01-koin-compiler-1.1.0-upgrade.md` and the user's `koin-compiler-a3-too-strict` memory.
+**1.1.0 validation model (this superseded the old A2/A3/A4 tiering; site docs still lag and
+describe A2 per-module validation — ignore that page's tiering).** Per-module validation was
+**removed entirely**; full-graph validation at `startKoin`/`koinApplication`/`@KoinApplication`
+is the sole compile-safety verifier. A compilation with no entry point gets generation only —
+`KOIN-D001/D004/D005/D006/P001` go silent there. So "per-module validation would catch X" is
+never a valid claim about this repo. `KOIN-W002` deleted; `KOIN-D008` (hint-name collision)
+added; `KOIN-W003` = dynamically-computed module set. `strictSafety` is now **mandatory** once an
+aggregator is auto-detected — a plain `strictSafety = false` is ignored, and the explicit escape
+hatch is `strictSafetyForceOff = true`. Gradle knobs: `compileSafety`, `strictSafety`,
+`strictSafetyForceOff`, `logSeverity`, `versionCheckSeverity`, `userLogs`, `debugLogs`,
+`unsafeDslChecks`, `skipDefaultValues` (+ undocumented `aiAssist`, which the repo sets false).
+The repo's `logSeverity = "info"` in the koin convention plugin is exactly the documented remedy
+for the new per-library-module "validation skipped" disclosure — current, do not flag.
+Sources: https://github.com/InsertKoinIO/koin-compiler-plugin/releases/tag/1.1.0 ,
+https://insert-koin.io/docs/setup/compiler-plugin/ , https://insert-koin.io/docs/reference/koin-annotations/options/
 
-**This repo uses the new Koin Kotlin Compiler Plugin** (`io.insert-koin.compiler.plugin`), NOT the old KSP processor. Applied in `build-logic/src/main/kotlin/ledger.kotlin.multiplatform.koin.gradle.kts`. So KSP args like `KOIN_CONFIG_CHECK` are N/A — don't go looking for them. Docs describe validation tiers A2 per-module / A3 full graph at `startKoin<T>()` / A4 call-site — **A2 no longer exists as of 1.1.0** (docs may lag). Docs: https://insert-koin.io/docs/intro/koin-compiler-plugin/
+**Known 1.1.0 bug affecting this repo — don't re-diagnose.** Full-graph validation ignores the
+`providerOnly` flag on a DSL `single<T> { … }` whose lambda builds `T`, so it walks `T`'s
+constructor and reports those params missing. `desktopApp` keeps `compileSafety = false` for this
+(DesktopUiTest's `RoomDatabase.Builder` override). NOT the multi-module false positive 1.0.2/1.1.0
+fixed. Upstream InsertKoinIO/koin-compiler-plugin#83; `docs/2026-08-01-koin-compiler-1.1.0-upgrade.md`.
 
-**`@Provided` — PINNED PROJECT DECISION, do not recommend removal.** Docs define it as "External dependency (skip validation)" (framework types like Android `Context`). The repo also uses it on cross-module use-case/ViewModel constructor params (14 sites in core/domain + feature impls). Per user project memory this is load-bearing: without it, compiler-plugin verification FAILS on those cross-Gradle-module edges. NB the stated mechanism (A2 per-module validation can't see other Gradle modules' definitions) no longer exists as of 1.1.0, so the *reason* may be stale even though the decision stands — if it ever comes up, re-test empirically rather than reasoning from A2. Still do not proactively recommend removal. Report only the *consequence* as informational: those edges are excluded from compile-time validation, so the docs' "you can remove verify()" guidance does NOT apply to this repo.
+**Compiler plugin, not KSP** (`io.insert-koin.compiler.plugin`, applied in
+`build-logic/src/main/kotlin/ledger.kotlin.multiplatform.koin.gradle.kts`). KSP args like
+`KOIN_CONFIG_CHECK` are N/A. `koin-ksp-compiler` is the deprecated path per the 4.2 release notes.
+Repo's catalog/plugin/dependency shape matches the documented setup verbatim.
 
-**`verify()` retention is justified here (not a currency gap).** Docs say compile-time safety "replaces verify() and checkModules() — no runtime test harness needed", BUT in this repo runtime `verify()` remains the only check for (a) the `@Provided`-excluded edges and (b) the DSL navigation modules (DSL isn't compiler-validated). verify() tests live in: `feature/settings/impl/src/jvmTest/.../di/KoinModuleTest.kt`, `feature/posting/impl/src/jvmTest/.../di/KoinModuleTest.kt`, `core/bootstrap/src/jvmTest/.../di/KoinModuleVerificationTest.kt` (uses `injectedParameters`/`definition<TopLevelDestination>` for DSL literals). CLAUDE.md's Kover section documents this reliance.
+**`@Provided` — PINNED PROJECT DECISION, never recommend removal.** Docs define it as "external
+dependency (skip validation)". The repo also uses it on cross-module use-case/ViewModel constructor
+params; per user memory it is load-bearing (verification fails without it). Note the *reason*
+originally given (A2 per-module validation can't see other Gradle modules) no longer exists as of
+1.1.0 — if it ever comes up, re-test empirically rather than reasoning from A2. Report only the
+consequence, informationally: those edges are excluded from compile-time validation, so the docs'
+"compile safety replaces verify()" line does not apply to this repo.
 
-**Current & correct in repo (do not flag):** `@KoinViewModel` + `@InjectedParam` for route ids + `parametersOf(route.id)` at call site; `@Module`/`@ComponentScan`/`@Single`/`@Factory`; `@KoinApplication(modules=[BootstrapModule::class])` + typed `startKoin<LedgerApp>` (`org.koin.plugin.module.dsl.startKoin`) in androidApp/desktopApp/iosExport `initializeKoin()`; `koinViewModel()` from koin-compose-viewmodel; nav3 integration = `navigation<NavKey>` DSL + `koinEntryProvider<NavKey>()` from koin-compose-navigation3, exactly matching https://insert-koin.io/docs/reference/koin-compose/navigation3 (still `@KoinExperimentalAPI` in code — docs don't mark it experimental, harmless). DSL is confined to `postingNavigationModule`/`settingsNavigationModule` (nav entries + `single(named("<feature>_top_level"))` multibinding workaround — annotations have no multibinding). expect-class `PlatformDatabaseModule`/`PlatformDataStoreModule` as `@Module` hosts work fine with the compiler plugin.
+**`verify()` retention is justified here (not a currency gap).** `Module.verify()` in koin-test
+4.2.2 carries **no `@Deprecated`** (checked in the tag's `VerifyModule.kt`) — only `checkModules()`
+was replaced by the Verify API. Runtime `verify()` remains the only check for (a) `@Provided`-excluded
+edges and (b) the DSL navigation modules, which are passed at `startKoin` and are not in the
+`@KoinApplication(modules=[BootstrapModule])` closure. Tests: `core/bootstrap` and both
+`feature/*/impl` jvmTest `di/KoinModule*Test.kt`.
+
+**CORRECTED 2026-09-06 — "Koin annotations have no multibinding" is FALSE at 4.2.2.** The earlier
+note (and CLAUDE.md) justified the DSL `single(named("<feature>_top_level")) { TopLevelDestination(…) }`
+by claiming two `@Single TopLevelDestination` would override each other. Overriding only happens on an
+identical (type, qualifier) key. `@Named` targets `CLASS, FUNCTION, VALUE_PARAMETER` in
+koin-annotations 4.2.2 (`CoreAnnotations.kt`), the definitions docs document the aggregation pattern
+(several `@Single @Named(...)` of one type, generated as `getAll()`), and 1.1.0 added regression
+coverage for `@Named` qualifier matching across Gradle module boundaries. So an annotated
+`@Single @Named("posting_top_level") fun …(): TopLevelDestination` is valid and would be picked up by
+the app shell's `getKoin().getAll<TopLevelDestination>()`. Only `navigation<T>` genuinely has no
+annotation equivalent. Source: https://insert-koin.io/docs/reference/koin-annotations/definitions/
+Caveat before recommending again: moving the definitions into `PostingModule`/`SettingsModule`
+changes *when* they load (BootstrapModule closure vs. the nav modules passed at `startKoin`) — that
+consequence is rv-di's call, not a currency judgement.
+
+**Verified current at 4.2.2 / plugin 1.1.0 — do not flag (re-checked 2026-09-06 against the 4.2.2
+tag sources, not docs prose):** `@KoinViewModel` imported from `org.koin.core.annotation` (the
+`org.koin.android.annotation` one is the deprecated path); `@InjectedParam` + `parametersOf` at the
+call site; `@Module`/`@ComponentScan(pkg)`/`@Single`/`@Factory`; `@KoinApplication` + typed
+`startKoin<LedgerApp>` (`org.koin.plugin.module.dsl.startKoin`) in all three entry points;
+`koinInject`/`koinViewModel`/`getKoin()` (**`getKoin()` is NOT deprecated** — only
+`LocalKoinApplication`/`LocalKoinScope` are, at ERROR level); `KoinIsolatedContext` (not deprecated);
+`koinConfiguration<T>` + `KoinApplication(configuration = …)` in `core/ui` AppTest — note the
+`KoinApplication(application = …)` lambda overload **is** `@Deprecated(WARNING)` at 4.2.2, the repo
+already avoids it; nav3 = `navigation<T>(metadata = …)` DSL + `koinEntryProvider<NavKey>()`, both
+still `@KoinExperimentalAPI` so the `@OptIn`s are required; `getAll<T>()` is explicitly sorted at
+the call site in `core/ui/App.kt`, which 4.2 requires (`getAll` no longer sorts by default).
+No Koin scopes are used anywhere in the repo, so the scope docs have no surface here.

--- a/.claude/agent-memory/bp-kotlin/MEMORY.md
+++ b/.claude/agent-memory/bp-kotlin/MEMORY.md
@@ -1,4 +1,4 @@
 # Memory Index
 
-- [Currency opt-ins](currency-optins.md) — ExperimentalUuidApi (Uuid.random) and ExperimentalCoroutinesApi (flatMapLatest) opt-ins are justified for pinned versions; don't flag
-- [Currency baseline](currency-baseline.md) — 2026-06-26 + 2026-07-02 audits found code current for Kotlin 2.4.0 / Coroutines 1.11.0 (both latest stable); lists confirmed patterns
+- [Currency opt-ins](currency-optins.md) — per-declaration opt-in status: flatMapLatest + subclassesOfSealed justified; the ExperimentalUuidApi one is STALE and removable (re-verified 2026-09-06)
+- [Currency baseline](currency-baseline.md) — 4 audits (last 2026-09-06) found the code current for the pinned Kotlin/coroutines; lists confirmed patterns + how to re-derive "is the pin still latest"

--- a/.claude/agent-memory/bp-kotlin/currency-baseline.md
+++ b/.claude/agent-memory/bp-kotlin/currency-baseline.md
@@ -1,24 +1,64 @@
 ---
 name: currency-baseline
-description: Baseline result of the Kotlin/coroutines upstream-currency audits (2026-06-26, re-audited 2026-07-02 and 2026-07-16) — what was checked and found current, so future audits can diff
+description: Baseline result of the Kotlin/coroutines upstream-currency audits (2026-06-26, re-audited 07-02, 07-16, 09-06) — what was checked and found current, so future audits can diff
 metadata:
   type: project
 ---
 
-Full-repo Kotlin-language + kotlinx.coroutines/Flow currency audits against pinned Kotlin 2.4.0 / Coroutines 1.11.0 / Serialization 1.11.0. Outcome all three times: code matches current official best practice — no Critical/Should-fix currency gaps.
+Full-repo Kotlin-language + kotlinx.coroutines/Flow currency audits against the pins in
+`gradle/libs.versions.toml`. Outcome all four times: no Critical/Should-fix currency gaps;
+one standing Optional (the stale `ExperimentalUuidApi` opt-in, see [[currency-optins]]).
 
-**Version currency confirmed 2026-07-16:** Kotlin 2.4.0 still latest stable (2.4.20 only in Beta1, planned Sep 2026 per kotlinlang.org/docs/releases.html + whatsnew-eap.html). kotlinx.coroutines 1.11.0 still latest stable per GitHub releases. kotlinx-serialization 1.11.0 pinned (aligned with the KMP release train). All three pins fully current — nothing newer to note. Between 2026-07-02 and 2026-07-16 NO `.kt` files changed (only dep bumps: Room 3.0.0 stable, Nav3 1.1.4, lifecycle 2.11.0-rc01), so the prior audit fully carries forward. Coroutines 1.11.0's one new deprecation (CoroutineDispatcher as context-key -> use ContinuationInterceptor) does NOT apply — repo has no `context[CoroutineDispatcher]` usage. No GlobalScope / runBlocking-in-main / manual Job() / `.values()`.
+**Rule, not numbers:** always re-read the pins, then re-derive "is the pin still the latest
+stable?" from the release feeds. Do not trust the sentence below on a later run.
 
-Patterns confirmed current (don't re-flag without a version bump or new upstream guidance):
-- `DataResult` + `Flow.asResult()` (map -> onStart emit Loading -> catch emit Error) — matches official Flow exception-transparency pattern.
-- ViewModels: `stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), initial)`, `flatMapLatest` over a retry `MutableStateFlow`, `combine` for UI state, `Channel(BUFFERED) + receiveAsFlow()` for one-shot events, `collectAsStateWithLifecycle` in screens. All current.
-- Repository: `withContext(dispatchers.io)` for writes, `.flowOn(dispatchers.io)` for cold read flows; injectable `AppDispatchers` seam.
-- 2026-07-02 additions audited and current: `DataStoreSettingsRepository` (`catch` + `emit(emptyPreferences())` on okio `IOException` only, rethrow others — correct Flow exception transparency), `SettingsViewModel` (combine + stateIn), theme flow in `App()` via `collectAsStateWithLifecycle(initialValue = SYSTEM)`, `ThemeMode.entries` (not `values()`), Navigator/NavBackStack code, `SetThemeModeUseCase` via `runCatchingCancellable`.
-- Build: no explicit languageVersion/apiVersion (defaults, correct); `-Xexpect-actual-classes` applied only in the 4 modules with expect classes — still required in 2.4.0 (expect/actual classes NOT in the 2.4.0 stable-features list per whatsnew24.html, checked 2026-07-02).
-- Language: `data object` for stateless sealed cases, exhaustive `when` over sealed interfaces, no deprecated stdlib APIs.
+**Version currency observed 2026-09-06** (`gh api .../releases`, authoritative):
+- Kotlin: pin `2.4.0`. Latest **stable is 2.4.10** (2026-07-14) — a bug-fix for 2.4.0;
+  2.4.20 is at RC3 (2026-09-02), targeted Sep 2026. The pin is deliberate (the catalog
+  comment ties it to the IntelliJ IDEA plugin ceiling, same reason as AGP), so report the
+  2.4.x gap only as a *note*, never as a gap. **This supersedes the 2026-07-16 note that
+  said "2.4.0 is still latest stable, 2.4.20 only in Beta1" — that expired on 2026-07-14.**
+- kotlinx.coroutines: pin `1.11.0` (released 2026-05-08) — still the latest stable. Current.
+- kotlinx-serialization: pin `1.11.0` (2026-04-09) — latest stable; 1.12.0-RC (2026-09-04)
+  is prerelease only. Current.
 
-Kotlin 2.4.0 stabilized: context parameters, explicit backing fields, `@all` meta-target, Uuid API (except V4/V7 generation — see [[currency-optins]]). Explicit backing fields could replace `_uiState`/`asStateFlow()` in PostingEditViewModel, but the official coding conventions (checked 2026-07-02) still document the `_name` backing-property convention and `asStateFlow()` prevents downcasting where an explicit backing field exposes the MutableStateFlow instance — reported as Optional-only; do not push as churn. Same for `extraWarnings.set(true)` (`-Wextra`, since Kotlin 2.1) — offered as Optional build hardening, not a gap.
+Patterns confirmed current (don't re-flag without a pin bump or new upstream guidance):
+- `DataResult` + `Flow.asResult()` (map -> onStart emit Loading -> catch emit Error) — matches
+  the official Flow exception-transparency pattern.
+- ViewModels: `stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), initial)`,
+  `flatMapLatest` over a retry `MutableStateFlow`, `combine` for UI state,
+  `Channel(BUFFERED) + receiveAsFlow()` for one-shot events, `collectAsStateWithLifecycle`
+  in screens, `_x` + `asStateFlow()` backing property. All current.
+- Repository: `withContext(dispatchers.io)` for writes, `.flowOn(dispatchers.io)` for cold
+  read flows; injectable `AppDispatchers` seam; common `Dispatchers.IO` (no opt-in needed).
+- `DataStoreSettingsRepository`: `catch` + `emit(emptyPreferences())` on okio `IOException`
+  only, rethrow others — correct Flow exception transparency.
+- Tests: `runTest`, `Dispatchers.setMain(UnconfinedTestDispatcher())` / `resetMain`,
+  `backgroundScope` for never-completing collectors (`EventCollect.kt`). Current idioms.
+- Language: `data object` for stateless sealed cases, exhaustive `when` over sealed
+  interfaces, `@JvmInline value class StartDestination`, `ThemeMode.entries` (not
+  `values()`). No `GlobalScope` / `runBlocking` / manual `Job()` / deprecated stdlib calls
+  (swept 2026-09-06: no `capitalize`/`toUpperCase()`/`sumBy`/`@Suppress("DEPRECATION")`).
+- Build: no explicit `languageVersion`/`apiVersion` (defaults, correct);
+  `extraWarnings.set(true)` is now ON in `ledger.kotlin.multiplatform` — the old Optional
+  suggestion is **done**, stop offering it. `-Xexpect-actual-classes` in the 4 modules with
+  expect classes is still required: expect/actual *classes* remain **Beta** in the KMP docs
+  (kotlinlang.org/docs/multiplatform-expect-actual.html, re-checked 2026-09-06).
+- Coroutines 1.11.0's one deprecation (CoroutineDispatcher as context key -> use
+  `ContinuationInterceptor`) does NOT apply: no `context[CoroutineDispatcher]` usage.
+- 1.11.0's new `SharedFlow.asFlow()` ("hide hot flow characteristics") is itself
+  `@ExperimentalCoroutinesApi`, so it is **not** a recommended replacement for the fakes'
+  `asStateFlow()` / `flow { emitAll(...) }`. Do not raise it as a finding.
 
-Out of lane (owned by rv-concurrency, not re-reviewed here): `runCatchingCancellable` cancellation correctness, asResult pipeline correctness. Note: as of coroutines 1.11.0 there is still no official stdlib/coroutines replacement for the runCatchingCancellable pattern (kotlinx.coroutines#1814 unresolved), so the custom helper remains the current best practice.
+Kotlin 2.4.0 stabilized: context parameters (except context arguments/callable refs),
+explicit backing fields, `@all` meta-target, the `kotlin.uuid.Uuid` API *except* the V4/V7
+**generation** functions. Explicit backing fields could replace `_uiState`/`asStateFlow()`
+in `PostingEditViewModel`, but kotlinlang.org/docs/coding-conventions.html still documents
+only the `_name` backing-property convention (re-checked 2026-09-06) and `asStateFlow()`
+prevents downcasting — Optional-only; do not push as churn.
 
-See [[currency-optins]] for the experimental opt-ins that are intentionally justified.
+Out of lane (owned by rv-concurrency): `runCatchingCancellable` cancellation correctness,
+`asResult` pipeline correctness. As of coroutines 1.11.0 there is still no official
+stdlib/coroutines replacement for the pattern (kotlinx.coroutines#1814 unresolved).
+
+See [[currency-optins]] for per-declaration opt-in status.

--- a/.claude/agent-memory/bp-kotlin/currency-optins.md
+++ b/.claude/agent-memory/bp-kotlin/currency-optins.md
@@ -1,15 +1,24 @@
 ---
 name: currency-optins
-description: Which experimental @OptIn annotations in the codebase are justified for pinned Kotlin 2.4.0 / Coroutines 1.11.0 (don't flag as removable)
+description: Which experimental @OptIn annotations in the codebase are justified for pinned Kotlin 2.4.0 / Coroutines 1.11.0 — and which are now stale (the Uuid one IS removable)
 metadata:
   type: project
 ---
 
-The two stdlib/coroutines experimental opt-ins in the repo are CORRECT for the pinned versions — do not propose removing them as "stale opt-ins."
+Status of every stdlib/coroutines/serialization experimental opt-in in the repo, against the pinned versions.
 
-- `@OptIn(ExperimentalUuidApi::class)` on `Uuid.random()` (core/common util/Uuid.kt): in Kotlin 2.4.0 the `kotlin.uuid.Uuid` class is Stable, BUT the V4/V7 generation functions (`Uuid.random()`) remain Experimental and still require opt-in. Verified 2026-06-26 against https://kotlinlang.org/docs/whatsnew24.html
-- `@OptIn(ExperimentalCoroutinesApi::class)` for `flatMapLatest` (PostingListViewModel, PostingDetailsViewModel): still `@ExperimentalCoroutinesApi` in kotlinx.coroutines 1.11.0. Verified 2026-06-26 against https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.flow/flat-map-latest.html
-- `@OptIn(ExperimentalSerializationApi::class)` on `subclassesOfSealed()` in the polymorphic `SerializersModule` (feature/*/api NavKeys — PostingNavKeys.kt, SettingsNavKeys.kt): `subclassesOfSealed` is still `@ExperimentalSerializationApi` in kotlinx-serialization 1.11.0 (the version pinned, aligned with the KMP release train). Verified 2026-07-16 against https://kotlinlang.org/api/kotlinx.serialization/kotlinx-serialization-core/kotlinx.serialization.modules/subclasses-of-sealed.html
+**STALE — flag this one as removable:**
 
-**Why:** "latest" is time-sensitive; re-confirm against the same docs if Kotlin/Coroutines versions are bumped. If Uuid generation graduates (post-2.4.0) the Uuid.kt opt-in becomes removable; if flatMapLatest graduates the ViewModel opt-ins become removable.
-**How to apply:** Only revisit these when the pinned versions in CLAUDE.md / libs.versions.toml change. Re-fetch the docs before asserting either way.
+- `@OptIn(ExperimentalUuidApi::class)` in `core/common/src/commonMain/kotlin/app/oreshkov/ledger/core/common/util/Uuid.kt:6` (plus the `kotlin.uuid.ExperimentalUuidApi` import on line 3) is **unnecessary** and should be reported as an Optional finding. `Uuid.random()` is Stable in Kotlin 2.4.0 — it carries no experimental marker and opts in internally: `public fun random(): Uuid = @OptIn(ExperimentalUuidApi::class) generateV4()` (stdlib 2.4.0, `commonMain/kotlin/uuid/Uuid.kt:581`). The `Uuid` class itself is `@SinceKotlin("2.4") @WasExperimental(ExperimentalUuidApi::class)` (`:53-55`), i.e. stable with no opt-in required **as long as the module's `apiVersion` is >= 2.4** — this repo sets no explicit `apiVersion`, so it defaults to 2.4 and removal is safe. Only the **generation** functions stay Experimental: `generateV4()` is `@SinceKotlin("2.3") @ExperimentalUuidApi` (`:617-619`), likewise `generateV7()` / `generateV7NonMonotonicAt()`. Re-verified 2026-09-06 (third confirmation) by unzipping `kotlin-stdlib-2.4.0-common-sources.jar` from the Gradle cache and reading the annotations, corroborated by https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.uuid/-uuid/-companion/random.html (shows the signature with no opt-in requirement) and https://kotlinlang.org/docs/whatsnew24.html ("the `kotlin.uuid.Uuid` API becomes Stable. The only exceptions are the functions for generating V4 and V7 UUIDs"). Still open in the code as of 2026-09-06.
+
+  > **Correction of a prior note.** Through 2026-08 this file claimed the opposite — that "the V4/V7 generation functions (`Uuid.random()`) remain Experimental" — and told future runs not to flag it. That conflated `Uuid.random()` with `Uuid.generateV4()`; they are different declarations with different markers. The old claim suppressed a valid finding for three audit passes. Do not restore it.
+
+**STILL JUSTIFIED — do not propose removing these:**
+
+- `@OptIn(ExperimentalCoroutinesApi::class)` for `flatMapLatest` (`PostingListViewModel.kt:27`, `PostingDetailsViewModel.kt:32`): still `@ExperimentalCoroutinesApi` in kotlinx.coroutines 1.11.0. Re-verified 2026-09-06 against https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.flow/flat-map-latest.html (page shows API version 1.11.0, signature annotated `@ExperimentalCoroutinesApi`).
+- `@OptIn(ExperimentalSerializationApi::class)` on `subclassesOfSealed()` in the polymorphic `SerializersModule` (`PostingNavKeys.kt:21`, `SettingsNavKeys.kt:15`): still `@ExperimentalSerializationApi` in kotlinx-serialization-core 1.11.0. Re-verified 2026-09-06 against https://kotlinlang.org/api/kotlinx.serialization/kotlinx-serialization-core/kotlinx.serialization.modules/subclasses-of-sealed.html (API version 1.11.0).
+- `@OptIn(ExperimentalSwiftExportDsl::class)` in `iosExport/build.gradle.kts:1`: still required in KGP 2.4.0. (Owned by [[kmp-structure-posture]] / bp-kmp; noted here so it is not double-flagged.)
+
+**Why:** "still experimental?" is a per-declaration, per-version fact, and the marker on a *wrapper* says nothing about the marker on what it calls. Reading the release notes alone is what produced the wrong Uuid entry — the notes say "the functions for generating V4 and V7 UUIDs remain Experimental", which is true but is not a statement about `random()`.
+
+**How to apply:** Re-check only when the pinned `kotlin` / `kotlinx-coroutines` / `kotlinx-serialization` versions in `gradle/libs.versions.toml` change. Verify by reading the declaration's own annotations in the published sources (the `kotlin-lib` MCP tools resolve these directly), not by inferring from a prose release note. Removing a stale `@OptIn` is source-only — no `apiDump` needed, since `@OptIn` has source retention and never appears in the `api/` dumps.

--- a/.claude/agent-memory/bp-room/MEMORY.md
+++ b/.claude/agent-memory/bp-room/MEMORY.md
@@ -1,3 +1,3 @@
 # bp-room Memory Index
 
-- [Room KMP currency baseline](currency-baseline.md) — what matches official Room KMP guidance; Room 3.0.0 stable out 2026-07-01; re-verified 2026-07-02
+- [Room KMP currency baseline](currency-baseline.md) — what matches official Room KMP guidance, verified against Room 3.0.0; the pin has since moved to 3.0.2, so re-confirm. No DataStore baseline yet — treat that half as never audited

--- a/.claude/agent-memory/bp-room/currency-baseline.md
+++ b/.claude/agent-memory/bp-room/currency-baseline.md
@@ -1,48 +1,74 @@
 ---
 name: currency-baseline
-description: Which parts of the Room KMP layer already match official Room 3.0.0 stable guidance (so future audits don't re-litigate them)
+description: Room KMP currency baseline for core:database — re-verified against the pinned Room 3.0.2 on 2026-09-06 against the official KMP Room guide and the room3 release notes
 metadata:
   type: project
 ---
 
-Room KMP layer (`core:database`) currency baseline, verified against the official
-KMP Room guide (developer.android.com/kotlin/multiplatform/room) and the Room 3.0
-release page (.../releases/room3). Last re-verified 2026-07-02 (docs last-updated
-2026-07-01; guide content substantively unchanged from the 2026-06-17 revision).
+Room KMP layer (`core:database`) currency baseline. **Re-verified 2026-09-06 against the
+pin `androidx-room = 3.0.2` / `androidx-sqlite = 2.7.0`** (read from
+`gradle/libs.versions.toml`, not from this note).
 
-**Stable is adopted (2026-07-16 re-verify):** repo now pins `androidx-room = "3.0.0"`
-and `androidx-sqlite = "2.7.0"` (both stable, released 2026-07-01). The earlier
-recommendation to bump off rc01 is DONE — no action. Release notes document no API
-delta between 3.0.0-rc01 and 3.0.0 stable.
+Sources read this round:
+- `developer.android.com/kotlin/multiplatform/room` — page last updated **2026-08-26**.
+- `developer.android.com/jetpack/androidx/releases/room3` — 3.0.2 released **2026-08-26**,
+  3.0.1 released **2026-07-29**. Both are **bug-fix only**: no API changes, no
+  deprecations, no setup changes vs 3.0.0. 3.0.2 is the newest Room 3 listed — there is
+  no 3.1.x. So the pin sits on the latest stable.
+- The pinned artifacts' own sources under the Gradle cache
+  (`C:\work\settings\gradle\caches\modules-2\files-2.1\androidx.room3\...`).
 
-**rc01 API rename note (N/A here):** 3.0.0-rc01 renamed `@TypeConverter` ->
-`@ColumnTypeConverter` (symmetry with `@DaoReturnTypeConverter`). The layer uses NO
-type converters (minimal 2-col String entity), so this rename does not apply. If a
-converter is ever added, use `@androidx.room3.ColumnTypeConverter`, not `@TypeConverter`.
+**Behaviour change to remember from 3.0.2:** suspending queries and invalidation-tracker
+operations now throw `IllegalStateException` if called after the database is closed
+(b/543076356). Harmless here — the DB is a Koin `@Single` that is never closed — but it
+would matter if a close/reopen lifecycle is ever added.
 
-The former `room3-sqlite-wrapper` version-pin defect is RESOLVED: the wrapper
-dependency was dropped from the repo entirely (see CHANGELOG). Don't re-flag.
-
-These already match current best practice — do not flag on re-audit unless docs change:
+These match current guidance — do not flag unless the docs or a future release note move:
 - `DatabaseModule.provideDatabase`: `.setDriver(BundledSQLiteDriver())` +
-  `.setQueryCoroutineContext(Dispatchers.IO)` + `.build()` — exactly the documented
-  common-code shape. (setQueryCoroutineContext defaults to Dispatchers.IO; setting it
-  explicitly is fine.)
-- Per-platform `RoomDatabase.Builder` providers: Android `databaseBuilder(context, name=
-  absolutePath)`, iOS NSDocumentDirectory pattern, JVM file path — all match docs
-  (JVM uses a real app-data dir, better than the docs' tmpdir example).
-- DAO: suspend for writes, `Flow<...>` for reads — current.
-- `@Database` schema export via `room3 { schemaDirectory(...) }`; `schemas/...
-  /LedgerDatabase/1.json` is present and tracked.
-- Migration posture: `.fallbackToDestructiveMigration(dropAllTables = true)` is the
-  current API (dropAllTables gained a default in 3.0.0-alpha02). This is a DELIBERATE
-  pre-release pin (see CLAUDE.md) — the comment describes it accurately. Mechanism is
-  current; before real data ship, replace with explicit `Migration` + exported-schema
-  CI check. Don't flag the posture itself.
-- KSP configured for all 4 compile targets (android, jvm, iosArm64, iosSimulatorArm64).
+  `.setQueryCoroutineContext(Dispatchers.IO)` + `.build()` — the exact common-code shape
+  in the KMP guide. (`setQueryCoroutineContext` defaults to `Dispatchers.IO`; setting it
+  explicitly is still what the guide shows.)
+- Per-platform `RoomDatabase.Builder` providers: Android `databaseBuilder(context, name =
+  absolutePath)`, iOS `NSDocumentDirectory`, JVM absolute path — all match the guide (the
+  JVM one uses a real OS data dir, better than the guide's `java.io.tmpdir` example).
+- `@ConstructedBy` + `expect object ... : RoomDatabaseConstructor<...>`. The guide now
+  shows `@Suppress("KotlinNoActualForExpect")` on the object where the code has
+  `@Suppress("NO_ACTUAL_FOR_EXPECT")` on the override — both compile; stylistic, not a gap.
+- DAO: `suspend` for writes/one-shot reads, `Flow<...>` for observed reads — current.
+- `SELECT *` in `PostingDao` is fine **because every one of those queries returns the whole
+  `PostingEntity`**, not a subset/POJO. (Correcting an earlier version of this note: the
+  reason is *not* "the entity is only 2 columns". `PostingEntity` has carried
+  `updatedAt` / `isDeleted` / `pendingSync` alongside `id` + `narrative` since 1.7.0. The
+  *domain* `Posting` is still id + narrative — see [[posting-entity-stays-minimal]] — but
+  the entity is not.)
+- Schema export via `room3 { schemaDirectory(...) }`; `schemas/.../LedgerDatabase/1.json`
+  present and tracked. Note the extension really is named `room3` here even though the
+  doc snippet writes `room { ... }`.
+- Migration posture `.fallbackToDestructiveMigration(dropAllTables = true)` — current API,
+  and a DELIBERATE pre-release choice (CLAUDE.md + the comment above it). Never flag the
+  posture. Before real user data ships: explicit `Migration` objects (KMP `Migration`
+  takes `SQLiteConnection`, not `SupportSQLiteDatabase`) + a CI check that the exported
+  schema changed on a version bump.
+- KSP configured for all four compile targets (android, jvm, iosArm64, iosSimulatorArm64).
+- In-memory test builders (`Room.inMemoryDatabaseBuilder<...>().setDriver(BundledSQLiteDriver())`)
+  omit `setQueryCoroutineContext`. Checked 2026-09-06: no official doc recommends pinning a
+  test dispatcher on the Room builder, so this is **not** a finding — don't invent one.
 
-Entity is intentionally minimal (id + narrative) — see user memory [[posting-entity-stays-minimal]];
-`SELECT *` in PostingDao is fine because the DAO returns the full (2-col) entity.
+**`room3-sqlite-wrapper` — deliberately absent, do not re-flag.** The KMP Room guide
+(2026-08-26) still lists `implementation(libs.androidx.room3.sqlite.wrapper)` under
+`androidMain`. This repo dropped it on purpose (CHANGELOG 1.5.0-era: "Dropped the unused
+`room3-sqlite-wrapper` dependency"; earlier review classed it hygiene, not currency). The
+reason still holds — verified 2026-09-06 that nothing in the repo references
+`SupportSQLite*` / `androidx.sqlite.db`. Re-open only if that stops being true.
 
-Conflict-strategy intent, mapper correctness, repository impl are owned by the
-`rv-data` agent — defer those, don't duplicate.
+`androidx-sqlite = 2.7.0` is exactly the version `room3-runtime-3.0.2.pom` declares, so
+the two pins are aligned; the KMP guide's own version table also shows room3 3.0.2 with
+sqlite 2.7.0.
+
+Conflict-strategy *intent*, mapper correctness and the repository impl belong to the
+`rv-data` agent — defer, don't duplicate.
+
+**How to apply:** always read the `androidx-room` / `androidx-sqlite` pins first. If they
+differ from 3.0.2 / 2.7.0, re-derive from the release notes for *those* versions before
+reusing any verdict here, then correct this note in place. DataStore has its own note:
+[[datastore-currency-baseline]].

--- a/.claude/agent-memory/bp-room/datastore-currency-baseline.md
+++ b/.claude/agent-memory/bp-room/datastore-currency-baseline.md
@@ -1,0 +1,71 @@
+---
+name: datastore-currency-baseline
+description: DataStore Preferences currency baseline for core:datastore — first audit 2026-09-06 against the pinned androidx-datastore 1.2.1; records what matches the KMP DataStore guide and the one artifact-choice gap
+metadata:
+  type: project
+---
+
+First real audit of the DataStore half of this agent's remit: **2026-09-06**, against the
+pin `androidx-datastore = 1.2.1` (read from `gradle/libs.versions.toml`).
+
+Sources read this round:
+- `developer.android.com/kotlin/multiplatform/datastore` — page last updated **2026-08-17**.
+- `developer.android.com/topic/libraries/architecture/datastore` — last updated **2026-08-27**.
+- `developer.android.com/jetpack/androidx/releases/datastore` — **1.2.1 stable 2026-03-11**
+  (no API/behaviour change vs 1.2.0, infra fixes only); 1.2.0 stable 2025-11-19. 1.2.1 is
+  the newest listed, so the pin sits on the latest stable. 1.2.x added `datastore-guava`,
+  Direct Boot (`createInDeviceProtectedStorage()` / `deviceProtectedDataStore()`),
+  `PreferencesFileSerializer`, a public `CorruptionHandler`, and a default constructor for
+  `ReplaceFileCorruptionHandler` — none of which changes this project's setup.
+- The pinned artifacts' own sources under the Gradle cache
+  (`...\modules-2\files-2.1\androidx.datastore\*\1.2.1\*-sources.jar`).
+
+**The single most useful thing verified this round — `createWithPath` is NOT stale.**
+The KMP guide's snippet builds the store per platform as
+`DataStoreFactory.create(storage = FileStorage(...))` on Android/JVM and
+`OkioStorage(FileSystem.SYSTEM, ...)` on iOS. The repo instead calls one shared
+`PreferenceDataStoreFactory.createWithPath { ... }` in commonMain. Reading the 1.2.1
+sources: the jvm/android actual of `createWithPath` delegates to
+`FileStorage(PreferencesFileSerializer)` and the native actual to
+`OkioStorage(FileSystem.SYSTEM, PreferencesSerializer)` — i.e. **exactly the storage the
+guide names, chosen per platform for you**. (The "default moved from OkioStorage to
+FileStorage" change is already inside the factory.) So the shared factory is equivalent to
+and simpler than the doc snippet. **Do not flag it, and do not propose rewriting
+`PreferencesDataStore.kt` into the guide's per-platform `Storage` form.**
+
+Also matching current guidance (do not flag):
+- `ReplaceFileCorruptionHandler { emptyPreferences() }` passed to the factory.
+- One `DataStore` instance per file: one `@Single` per platform actual, and the desktop UI
+  test builds its own store in a per-test temp dir. The docs' hard rule ("never more than
+  one instance for a given file in the same process; DataStore throws `IllegalStateException`")
+  is respected.
+- File name `ledger.preferences_pb` — the factory asserts the `preferences_pb` extension on
+  both jvm/android and native, so the name is load-bearing.
+- Reads: `dataStore.data` `Flow` + `.map`; writes: `edit {}`. No blocking reads anywhere.
+- Read-side `IOException` -> `emit(emptyPreferences())` — the documented recovery.
+- Per-platform paths: Android `filesDir` (matches the guide), iOS `NSDocumentDirectory`
+  (matches verbatim), JVM OS-aware app-data dirs (better than the guide's `java.io.tmpdir`,
+  and the guide itself says to prefer an app-support dir).
+
+**Open gap found (Optional): artifact choice.** `core/datastore/build.gradle.kts` (and the
+desktopApp test deps) declare the umbrella `androidx.datastore:datastore` +
+`androidx.datastore:datastore-preferences`, while the KMP guide's commonMain block names
+`datastore-core` + `datastore-preferences-core`. Verified from the sources jars that the
+umbrella artifacts are the `-core` ones plus delegate glue (`DataStoreDelegateUtils`,
+`PreferencesDataStoreDelegateUtils`, and on Android `PreferenceDataStoreDelegate`,
+`PreferenceDataStoreFile`, `SharedPreferencesMigration`) that this project never uses.
+
+**okio types in commonMain are legitimate here.** The code imports `okio.Path.Companion.toPath`
+and `okio.IOException` without declaring okio: `datastore-preferences-core` exposes okio as
+`api` (its `createWithPath` signature takes an `okio.Path`), so it is on the compile
+classpath either way. Platform mapping checked in the 1.2.1/okio 3.x sources:
+- jvm/android: `okio.IOException` *is* `java.io.IOException` (typealias), and
+  `androidx.datastore.core.IOException` is the same typealias -> one catch covers all.
+- native: `androidx.datastore.core.IOException` is its **own class extending `Exception`**,
+  unrelated to `okio.IOException`. Read failures on iOS come out of `OkioStorage` as
+  `okio.IOException` (covered), but `CorruptionException` extends the *datastore*
+  `IOException` and so is **not** covered on iOS if it ever escapes the corruption handler.
+
+**How to apply:** read the `androidx-datastore` pin before reusing anything here. If it is
+no longer 1.2.1, re-derive from that release's notes and the cached sources. Room has its
+own note: [[currency-baseline]].

--- a/.claude/agent-memory/bp-testing/MEMORY.md
+++ b/.claude/agent-memory/bp-testing/MEMORY.md
@@ -1,3 +1,3 @@
 # Memory Index
 
-- [Test-stack currency notes](test-stack-currency-notes.md) — verified 2026-07-02: coroutines 1.11.0 / CMP 1.11.1 (v2 UI-test API) / Kover 0.9.8 all latest; repo fully on v2; zero gaps
+- [Test-stack currency notes](test-stack-currency-notes.md) — v2 UI-test adoption + coroutines-test facts; the "CMP 1.11.1 / Kover 0.9.8 are latest" claims EXPIRED (now 1.12.0 / 0.9.9) — re-derive version claims before reuse

--- a/.claude/agent-memory/bp-testing/test-stack-currency-notes.md
+++ b/.claude/agent-memory/bp-testing/test-stack-currency-notes.md
@@ -1,41 +1,56 @@
 ---
 name: test-stack-currency-notes
-description: Verified upstream currency facts for the test toolchain (coroutines-test 1.11.0, Compose MP 1.11.1 v2 UI-test API, Kover 0.9.8) as of 2026-07-02
+description: Test-toolchain currency facts (coroutines-test, Compose MP v2 UI-test API, Kover). Content verified 2026-07-16 against CMP 1.11.1 / Kover 0.9.8 — BOTH PINS HAVE SINCE MOVED; re-derive before reuse
 metadata:
   type: project
 ---
 
-Test-stack currency facts verified 2026-07-02, re-verified 2026-07-16 — unchanged
-(re-verify before reusing; versions move). 2026-07-16 re-check: coroutines 1.11.0 still
-latest stable, CMP 1.12.0 still beta-only (1.12.0-beta02 shipped 2026-07-01), Kover 0.9.8
-still latest — no newer stable release changes the advice. Full repo re-scanned: still zero
-upstream-currency gaps.
+> **STALE BASELINE — corrected 2026-09-06.** This note asserted "Compose MP 1.11.1 is
+> the latest stable" and "Kover 0.9.8 is the latest release". Both were true on
+> 2026-07-16 and are false now: the catalog pins **CMP 1.12.0** (stable, released
+> 2026-08-26) and **Kover 0.9.9**. Its old "How to apply" told the next run to diff
+> against those baselines instead of re-deriving — which is exactly how a stale number
+> survives an audit. **Read the pins from `gradle/libs.versions.toml` first; every
+> version claim below is a dated observation, not a current fact.**
 
-- **kotlinx-coroutines 1.11.0 is the latest release** (per CHANGES.md on master). Its only
-  test-module change: advanced deprecations of the `runTest(dispatchTimeout=...)` overloads
-  to ERROR and removed the long-ERROR `TestCoroutineScope` APIs (PR #4604). This repo uses
-  none of them.
-- **Compose MP 1.11.1 is the latest stable** (released 2026-06-02; 1.12.0-beta01 out
-  2026-06-30, pre-release only). CMP 1.11.0 made the **v2 test APIs the default and
-  deprecated v1** `runComposeUiTest`/`runDesktopComposeUiTest`/`runSkikoComposeUiTest`.
-  v2 lives in `androidx.compose.ui.test.v2` (common) and
-  `androidx.compose.ui.test.junit4.v2` (Android rules: `createAndroidComposeRule` etc.).
-  v2 defaults to **StandardTestDispatcher** (queued) instead of UnconfinedTestDispatcher,
-  and adds an `effectContext` parameter. The API is still `@ExperimentalTestApi`.
+Test-stack currency facts, last genuinely verified 2026-07-02 and re-verified
+2026-07-16 against the versions pinned *at that time*.
+
+- **kotlinx-coroutines 1.11.0** (still the pinned version as of 2026-09-06, and still
+  latest stable at that date). Its only test-module change: advanced deprecation of the
+  `runTest(dispatchTimeout=...)` overloads to ERROR and removal of the long-ERROR
+  `TestCoroutineScope` APIs (PR #4604). This repo uses none of them.
+- **Compose MP v2 UI-test API** — verified against CMP 1.11.1; **not re-checked against
+  the pinned 1.12.0.** CMP 1.11.0 made the v2 test APIs the default and deprecated v1
+  `runComposeUiTest`/`runDesktopComposeUiTest`/`runSkikoComposeUiTest`. v2 lives in
+  `androidx.compose.ui.test.v2` (common) and `androidx.compose.ui.test.junit4.v2`
+  (Android rules: `createAndroidComposeRule` etc.), defaults to **StandardTestDispatcher**
+  (queued) rather than UnconfinedTestDispatcher, and adds an `effectContext` parameter.
+  The API was still `@ExperimentalTestApi` at 1.11.1 — **re-confirm on 1.12.0 before
+  asserting the opt-in is still required.**
   Sources: https://kotlinlang.org/docs/multiplatform/whats-new-compose-111.html ,
   https://kotlinlang.org/docs/multiplatform/compose-test.html ,
   https://developer.android.com/develop/ui/compose/testing/migrate-v2
-- **This repo is already fully on v2** everywhere (common screen tests, DesktopUiTest's
+- **The repo is already fully on v2** everywhere (common screen tests, DesktopUiTest's
   `runDesktopComposeUiTest`, androidApp SmokeTest's `junit4.v2.createAndroidComposeRule`).
-  Do not re-flag v1→v2 migration.
-- **Kover 0.9.8 is the latest release** (2026-03-25).
-- coroutines-test docs still mark much of the module `@ExperimentalCoroutinesApi`, so the
+  Structural, not version-dependent — do not re-flag a v1 to v2 migration.
+- coroutines-test still marks much of the module `@ExperimentalCoroutinesApi`, so the
   blanket `@OptIn(ExperimentalCoroutinesApi::class)` on test classes using
-  `UnconfinedTestDispatcher`/`setMain` is required, not stale.
-- Audit outcome 2026-07-02: **zero upstream-currency gaps** in the test suites. setMain is
-  paired with resetMain in every class; no legacy runBlockingTest/TestCoroutineDispatcher;
-  no real-time waits (uses `waitForIdle`/`waitUntilExactlyOneExists`).
+  `UnconfinedTestDispatcher`/`setMain` is required, not stale. (Verified for 1.11.0, the
+  pinned version — re-check only if that pin moves.)
+- Audit outcome 2026-07-02 and 2026-07-16: **zero upstream-currency gaps** in the test
+  suites. setMain paired with resetMain in every class; no legacy
+  `runBlockingTest`/`TestCoroutineDispatcher`; no real-time waits (uses `waitForIdle` /
+  `waitUntilExactlyOneExists`). This verdict predates the CMP 1.12.0 bump.
 
-**How to apply:** in future audits, diff against these baselines instead of re-deriving;
-only re-fetch release pages to see if anything newer than coroutines 1.11.0 / CMP 1.11.1 /
-Kover 0.9.8 shipped.
+**Why:** the previous version of this note is the clearest example in the repo of how a
+currency memory fails — it was accurate when written, framed dated observations as
+standing facts, and instructed the next run to trust them. A note that says "X is the
+latest" is wrong the moment X ships a successor.
+
+**How to apply:** read the pinned `compose-multiplatform`, `kotlinx-coroutines` and
+`kover` versions from `gradle/libs.versions.toml` and compare them to the versions each
+claim above names. Where they differ, treat that claim as **unverified** and re-derive it
+from the release notes or the pinned artifact's own sources before reusing it. When you
+re-derive one, correct this note in place — writes under `.claude/agent-memory/` are
+permitted.

--- a/.claude/skills/currency-findings-contract/SKILL.md
+++ b/.claude/skills/currency-findings-contract/SKILL.md
@@ -21,6 +21,23 @@ the pins it names may since have moved. Review the code against the official gui
 *those* releases. If a newer stable release changes the advice, say so as a
 **separate** note — do not fold "you could upgrade" into "you are doing it wrong".
 
+### Audit your own memory as you use it
+
+A stored note is evidence, not authority. Before relying on any entry, check the versions
+it names against the pins you just read, and check the date it was verified. If a pin
+moved, that entry is **unverified** — re-derive it from the primary source (the pinned
+artifact's own sources, or the release notes for *that* release) before reusing it.
+
+Two failure modes have already cost this project real findings, so expect both:
+- a note that says **"X is the latest"** — true when written, false the moment X ships a
+  successor;
+- a note that says **"do not flag Y"** — a verdict whose evidence can expire while the
+  wording still reads as settled fact.
+
+When you find an entry that is wrong or expired, **correct it in place** — writes under
+`.claude/agent-memory/` are permitted — and say so in your report. A correction that
+lives only in the report dies with the run, and the next run re-inherits the bad note.
+
 ## Cite or drop it
 
 An uncited best-practice claim is invalid: "latest" is time-sensitive, and your
@@ -39,7 +56,10 @@ internal correctness (that belongs to your `rv-*` pair — see the ownership mat
 Respect deliberate, documented project decisions. A pin that CLAUDE.md, this repo's
 docs, or your agent memory records as intentional is **not** a finding; at most, note
 whether the *reason* for it still holds. Generating churn against a decision the
-project already made is worse than reporting nothing.
+project already made is worse than reporting nothing. But "intentional" carries the
+*reason*, not a licence: when that reason no longer holds — an alignment pin whose
+upstream alignment moved, an opt-in whose API graduated — it **is** a finding, and the
+note recording it needs correcting.
 
 ## Finding format
 
@@ -61,6 +81,9 @@ manufactured Optional findings makes the whole sweep less trustworthy.
 
 - Persist durable currency notes to your agent memory (e.g. "the coroutines guide as
   of <date> recommends X for 1.11") so the next run starts warmer.
+- **Correct what you found wrong.** If a stored note's version claims or verdicts expired,
+  rewrite that note in place rather than appending a contradictory one, and list the
+  corrections in your report. State the rule ("match what CMP declares"), not the number.
 - You are **read-only**: propose fixes, never apply them. A `PreToolUse` hook enforces
   this — `Write`/`Edit` outside `.claude/agent-memory/` is blocked.
 - If you hit your `maxTurns` limit, say which parts of your domain you did **not**

--- a/.gitattributes
+++ b/.gitattributes
@@ -30,3 +30,10 @@ gradlew text eol=lf
 *.png  binary
 *.ico  binary
 *.icns binary
+
+# Claude Code definitions. The agent loader does not parse CRLF frontmatter, so a
+# Windows checkout (where `core.autocrlf=true` gives them CRLF) silently drops every
+# agent in `.claude/agents/`. The hook is a POSIX shell script and needs LF to run
+# under Git Bash. Pin the working-tree form to LF, as with the `*.api` dumps above.
+.claude/**/*.md text eol=lf
+.claude/**/*.sh text eol=lf


### PR DESCRIPTION
## Summary

Two follow-ups to #28, both in `.claude/` — no application, build, or test code changes.

**1. Pin `.claude` text files to LF (`.gitattributes`).**
With `core.autocrlf=true` and no rule covering `.claude`, a Windows checkout materialised every agent definition with CRLF line endings, and the agent loader does not parse CRLF frontmatter — so all twenty `rv-`/`bp-` agents were silently dropped from the Agent tool with no error. The guard hook, a POSIX shell script, was affected the same way. The committed blobs were LF throughout, so only the working copy was ever wrong; this pins the working-tree form to LF the same way `*.api` and `gradlew` already are.

**2. Make the currency agents audit and correct their own memory.**
The nine `bp-` agents trusted their stored notes, and six of those notes had expired. Four were actively suppressing findings — a claim that `Uuid.random()` is still experimental hid a removable opt-in for three consecutive passes, and notes asserting "CMP 1.11.1 is the latest stable" or vouching for a `material3` pin the project no longer has were treated as settled fact. One note pointed at a build block deleted months ago (a phantom finding waiting to happen), and one index line contradicted the body of the note it pointed at.

The contract already said never to assert a version from memory, but it also told agents that anything memory records as intentional is not a finding, with nothing requiring them to check whether the reason still held. It now carries an "audit your own memory as you use it" rule: check a stored entry against the pins before relying on it, and correct it in place rather than only mentioning the correction in a report that dies with the run.

Also adds the first DataStore baseline for `bp-room`, whose remit was extended to cover it without the memory ever being audited for that half.

## Related issue

n/a

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / cleanup
- [ ] Build / CI
- [ ] Documentation

## Checklist

- [x] Tests pass locally (`./gradlew allTests`) — n/a, no build inputs changed (`.claude/**` and `.gitattributes` only)
- [x] Checks pass (`./gradlew check`) — n/a, as above
- [x] Documentation updated where relevant (`.claude/agents/README.md`, `.claude/REVIEW-CONVENTIONS.md`)
- [x] Changes follow the project's architecture and conventions (see `CLAUDE.md` / `README.md`)

---

Note for existing checkouts: the LF pin only takes effect on checkout, so working copies that already have the CRLF files keep them until refreshed (strip the CRs, then `git add --renormalize .claude`) or re-cloned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D5ERoAm7SzSDEupb9BPc4w
