### PR TITLE
chore(claude): refresh bp- agent memory from the 2026-09-06 currency pass

### DIFF
--- a/.claude/agent-memory/bp-android/MEMORY.md
+++ b/.claude/agent-memory/bp-android/MEMORY.md
@@ -1,4 +1,4 @@
 # Memory Index
 
-- [Backup and privacy posture](backup-and-privacy-posture.md) — backup deliberately OFF, zero permissions, local-first; confirm don't re-flag
-- [SDK and behavior currency](sdk-and-behavior-currency.md) — compile/target 37 (Android 17), min 24; which targetSdk-37 behavior changes are relevant vs N/A
+- [Backup and privacy posture](backup-and-privacy-posture.md) — backup deliberately OFF (both rule files are load-bearing), zero permissions; verified 2026-09-06
+- [SDK and behavior currency](sdk-and-behavior-currency.md) — API 37 facts, AGP max-API, Play target-API + 16 KB deadlines, which API-37 behavior changes apply; verified 2026-09-06

--- a/.claude/agent-memory/bp-android/backup-and-privacy-posture.md
+++ b/.claude/agent-memory/bp-android/backup-and-privacy-posture.md
@@ -1,15 +1,36 @@
 ---
 name: backup-and-privacy-posture
-description: Android target is local-first with backup deliberately disabled and zero permissions — confirm, don't re-flag, in currency audits
+description: Android target is local-first with backup deliberately disabled and zero permissions — verified against current backup docs 2026-09-06; confirm, don't re-flag
 metadata:
   type: project
 ---
 
-The `androidApp` target is intentionally local-first and privacy-minimal. Confirm these on each currency audit rather than proposing to "add" anything.
+The `androidApp` target is intentionally local-first and privacy-minimal. Confirm these on each
+currency audit rather than proposing to "add" anything.
 
-- **Backup deliberately OFF** (commit adca851): `android:allowBackup="false"` plus both `data_extraction_rules.xml` (cloud-backup + device-transfer) and `backup_rules.xml` exclude every domain. The exclude-all rule files are intentionally redundant with `allowBackup=false` — they silence lint and keep intent explicit. This is a pinned decision; do not propose re-enabling backup.
-- **Zero permissions**: the manifest declares no `uses-permission`. Correct for a local-first ledger; do not propose storage/network/legacy permissions.
-- **Single exported component**: only `MainActivity` (LAUNCHER), `exported="true"` correctly.
+- **Backup deliberately OFF** (commit adca851): `android:allowBackup="false"` plus both
+  `data_extraction_rules.xml` (cloud-backup + device-transfer) and `backup_rules.xml` exclude every
+  domain. The exclude-all rule files are intentionally redundant with `allowBackup=false` — they
+  silence lint and keep intent explicit. Pinned decision; never propose re-enabling backup.
+- **Zero permissions**: the app manifest declares no `uses-permission`. Verified 2026-09-06 against
+  the *merged* debug manifest too: the only entry is the signature-level
+  `DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION` androidx.core injects. No INTERNET, no storage.
+- **Single exported component**: only `MainActivity` (LAUNCHER). The merged manifest also carries
+  upstream's `androidx.profileinstaller.ProfileInstallReceiver` (`exported="true"` but guarded by
+  `android.permission.DUMP`) — that is library-owned and expected, not a finding.
+
+**Verified against upstream 2026-09-06** (developer.android.com/identity/data/autobackup,
+page updated 2026-02-26): the redundancy is *load-bearing*, not decorative — on Android 12+ some
+OEMs treat `allowBackup="false"` as disabling cloud backup only, leaving device-to-device transfer
+on; the `<device-transfer>` excludes are what actually close that path. Keep both rule files.
+
+**Known doc-vs-platform nit:** the docs call `path` a required attribute on `<include>`/`<exclude>`;
+these rule files omit it. AOSP `FullBackup.extractCanonicalFile` explicitly tolerates that
+("Allow things like `<include domain="sharedpref"/>`", `filePathFromXml = ""`), so the excludes do
+take effect. Adding `path="."` is a documented-syntax nicety only — never report it above Optional,
+and never as a data-leak.
 
 **Why:** local-first app, ledger DB must never leave the app sandbox.
-**How to apply:** a currency audit should *verify these still hold* against current Android backup/privacy guidance and report "matches best practice," not invent gaps. Related: [[sdk-and-behavior-currency]].
+**How to apply:** a currency audit should *verify these still hold* against current Android
+backup/privacy guidance and report "matches best practice," not invent gaps.
+Related: [[sdk-and-behavior-currency]].

--- a/.claude/agent-memory/bp-android/sdk-and-behavior-currency.md
+++ b/.claude/agent-memory/bp-android/sdk-and-behavior-currency.md
@@ -1,21 +1,55 @@
 ---
 name: sdk-and-behavior-currency
-description: Android SDK levels (compile/target 37, min 24) and which targetSdk-37 behavior changes are relevant vs N/A for this app
+description: Android SDK levels (compile/target 37, min 24), AGP max-API support, Play target-API + 16 KB page-size requirements, and which API-37 behavior changes are relevant vs N/A
 metadata:
   type: project
 ---
 
-SDK levels live in `gradle/libs.versions.toml`: `android-sdk-compile = 37`, `android-sdk-target = 37`, `android-sdk-min = 24`. AGP 9.1.0.
+Pins live in `gradle/libs.versions.toml` — **always re-read them, never quote the numbers below as current**:
+`android-sdk-compile`, `android-sdk-target`, `android-sdk-min`, `android-gradle-plugin`.
+Values observed 2026-09-06: compile 37, target 37, min 24, AGP **9.1.1** (an earlier
+version of this note said 9.1.0 — the pin moved; re-derive every run).
 
-Currency facts (re-verified 2026-07-16): API 37 = Android 17, stable June 2026 — the latest level, exceeding Google Play's Aug 31 2026 requirement (API 36 for new apps/updates, API 35 to stay visible on existing apps). AGP 9.1.0 is on a current stable line and supports API 37. So SDK/AGP currency is ahead of, not behind, requirements. **Do not flag AGP as "behind latest" (9.3.0):** it is deliberately pinned to 9.1.0 because that is the ceiling the latest IntelliJ IDEA Android plugin supports (IDEA lags Android Studio on AGP). See [[gradle-currency-baseline]].
+**Currency facts (re-verified 2026-09-06):**
+- API 37 = Android 17 is the **latest stable**; no Android 18 preview yet, only Android 17
+  QPR1 beta / Canary (developer.android.com/about/versions).
+- Play target-API requirement is **now in force** (since 2026-08-31): new apps and updates
+  must target API 36+; existing apps need API 35+ to stay visible on new devices; extension
+  window to 2026-11-01 (developer.android.com/google/play/requirements/target-sdk).
+  targetSdk 37 is one level *ahead* of the requirement.
+- **AGP 9.1.1 supports API level 37 and below** — compileSdk 37 is a supported combination,
+  not an over-reach (past-releases/agp-9-1-0-release-notes, updated 2026-08-28). Gradle min
+  for AGP 9.1.1 is 9.3.1; wrapper is above that. Do not re-file "compileSdk exceeds AGP".
+  The AGP pin itself is deliberate (IntelliJ IDEA plugin ceiling) — see [[gradle-currency-baseline]].
+- **16 KB page size**: Play rejects updates without it from **2027-02-01** for apps targeting
+  API 35+ that ship native code (guide/practices/page-sizes, updated 2026-08-23). This app
+  *does* ship native code — `BundledSQLiteDriver` pulls `libsqliteJni.so` from
+  `androidx.sqlite:sqlite-bundled`. Verified 2026-09-06 by parsing ELF program headers of the
+  cached AAR: every LOAD segment has `p_align=16384` on arm64-v8a and x86_64. AGP >= 8.5.1
+  does the APK-side alignment. Compliant — re-check only if the sqlite pin moves.
 
-R8 release config: RESOLVED (verified 2026-07-16). `androidApp/build.gradle.kts` release buildType now has `isMinifyEnabled = true`, `isShrinkResources = true`, and `proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")`. `proguard-rules.pro` is intentionally near-empty (Room 3 / Compose / kotlinx-serialization ship consumer keep rules; Koin Annotations is compile-time codegen). The earlier "isMinifyEnabled = false" gap is closed — do not re-flag.
+**targetSdk-37 behavior changes → this app** (mapping stable unless the app gains features;
+list re-read 2026-09-02 revision of about/versions/17/behavior-changes-17):
+- **Edge-to-edge**: enforced since targetSdk 35. `MainActivity` calls `enableEdgeToEdge()` and
+  the activity sets `windowSoftInputMode="adjustResize"` — exactly the two steps the current
+  setup-e2e guide (2026-09-02) lists. OK.
+- **Predictive back**: default-on for targetSdk 36+; `android:enableOnBackInvokedCallback` is
+  only an *opt-out* now and is correctly absent. Requires activity >= 1.6.0 (pin is far above).
+  Back *handling* in Compose is bp-compose's lane.
+- **Large-screen orientation/resizability**: ignored on sw>=600dp with **no opt-out** on API 37.
+  Manifest sets no orientation/resizeability/aspect-ratio restriction — ready.
+- N/A for this app: local-network permission, background-audio hardening, SMS OTP, CP2/contacts,
+  ECH + certificate transparency (no INTERNET permission at all), RemoteViews memory limit,
+  BluetoothSocket, `setContentCaptureEnabled`. Native DCL hardening is N/A too: the sqlite lib
+  is packaged in the APK (`extractNativeLibs=false`), not `System.load()`-ed from writable storage.
 
-targetSdk-37 behavior changes and how they map to this app:
-- **Edge-to-edge**: enforced (targetSdk 35+). `MainActivity` calls `enableEdgeToEdge()`. OK.
-- **Predictive back**: on by default for targetSdk 36+; the `android:enableOnBackInvokedCallback` flag is NOT needed and is correctly absent. Actual back *handling* in Compose is bp-compose's lane.
-- **Large-screen orientation/resizability restrictions**: mandatory on API 37 (no opt-out). App is adaptive (material3 adaptive-navigation3) and sets no orientation/resizeable restrictions in the manifest — consciously ready. Layout adaptation itself is bp-compose's lane.
-- Most other API-37 changes (background audio, contacts/CP2, local-network permission, SMS OTP, native DCL) are N/A — app has no such features.
+**Test-device coverage caveat:** `androidApp/build.gradle.kts` defines one Gradle-managed device
+at API 30 (`aosp-atd`). ATD system images exist **only at API 30** (studio/test/gradle-managed-devices,
+2026-01-16), so covering API 37 behavior changes needs a second device on the `aosp`/`google` source.
+
+R8 release config: RESOLVED (verified 2026-07-16, still true 2026-09-06) — release buildType has
+`isMinifyEnabled`/`isShrinkResources` true with `proguard-android-optimize.txt`. Do not re-flag.
 
 **Why:** keeps future currency audits from re-deriving the same SDK/behavior-change mapping.
-**How to apply:** re-verify the "latest level / Play requirement" facts when the calendar advances; the behavior-change mapping is stable unless the app gains features. Related: [[backup-and-privacy-posture]].
+**How to apply:** re-read the pins first, then re-verify the dated claims above; the N/A mapping
+only changes when the app gains features. Related: [[backup-and-privacy-posture]].

--- a/.claude/agent-memory/bp-ci/MEMORY.md
+++ b/.claude/agent-memory/bp-ci/MEMORY.md
@@ -1,3 +1,3 @@
 # Memory Index
 
-- [Supply-chain posture (2026-07)](supply-chain-posture.md) — 4 workflows SHA-pinned, least-priv, attested; open: retry-on-snapshot-warnings, immutable releases, env-scoped signing secrets
+- [Supply-chain posture (2026-09-06)](supply-chain-posture.md) — pins/permissions current, immutable releases ON; gaps: Dependabot skips the composite action, Scorecard Signed-Releases=0

--- a/.claude/agent-memory/bp-ci/supply-chain-posture.md
+++ b/.claude/agent-memory/bp-ci/supply-chain-posture.md
@@ -1,35 +1,73 @@
 ---
 name: supply-chain-posture
-description: kmp-ledger GitHub Actions supply-chain hardening posture, what already matches upstream best practice, and open items (as of 2026-07-16 re-audit)
+description: kmp-ledger GitHub Actions supply-chain hardening posture — what already matches upstream best practice, structural gaps (Dependabot blind spot, Scorecard Signed-Releases), and open items (re-audited 2026-09-06)
 metadata:
   type: project
 ---
 
-Snapshot of `.github/workflows/` CI/supply-chain posture, re-audited 2026-07-16 against the GitHub Actions secure-use reference, gradle/actions v6 docs, and OpenSSF Scorecard. **Five** workflows now: build, dependency-review, release, dependency-submission, and **scorecard** (added since the 2026-07-02 audit).
+Snapshot of the CI/supply-chain posture, re-audited **2026-09-06** against the GitHub
+Actions secure-use reference, GitHub artifact-attestation / immutable-release docs,
+gradle/actions v6 release notes, and OpenSSF Scorecard v5.5.0. Five workflows: build,
+dependency-review, release, dependency-submission, scorecard — plus one **composite
+action**, `.github/actions/gradle-setup/action.yml`.
 
 **Already current (do not re-flag as gaps):**
-- All actions pinned to full 40-hex SHA with version comments; every pin re-verified 2026-07-16 to resolve to a real tag. Dependabot (github-actions, weekly, grouped) keeps them bumped — pins lagging latest by a patch/minor between weekly runs is normal, not a finding.
-- Top-level `permissions: contents: read` (scorecard uses `read-all`) in all workflows; jobs widen minimally. dependency-submission's job-level `contents: write` on pull_request is the upstream-documented pattern. Satisfies Token-Permissions.
-- `persist-credentials: false` set on **every** checkout.
-- Concurrency deliberate and correct: PR-triggered cancel-in-progress true; release false. Every job has `timeout-minutes`. No `pull_request_target`; no `github.event.*` in `run:` (ci-success interpolates only `needs.*.result` enum values).
-- Release uses `actions/attest` v4.1.1 **directly** (Provenance mode, auto SLSA build provenance). id-token + attestations write scoped to create-release job only.
-- **Signing secrets now scoped to a protected `environment: release`** in release.yml build-android (resolves the prior Optional item about moving ANDROID_KEYSTORE_* into a deployment environment).
-- **scorecard.yml matches the official OpenSSF template**: SHA-pinned scorecard-action + codeql-action/upload-sarif, `read-all` top-level, job-level `security-events: write` + `id-token: write`, `publish_results: true`, triggers branch_protection_rule/schedule/push-main/workflow_dispatch.
-- Gradle wrapper validation covered (setup-gradle default true) plus an explicit gradle/actions/wrapper-validation step in build.yml (needed for Scorecard Binary-Artifacts gradle-wrapper exemption).
+- All `uses:` pinned to full 40-hex SHA with version comments; every pin re-resolved to
+  a real tag on 2026-09-06. Every workflow-file pin was exactly latest at audit time.
+- Top-level `permissions: contents: read` (scorecard uses `read-all`); jobs widen
+  minimally. `persist-credentials: false` on every checkout. Every job has
+  `timeout-minutes`. No `pull_request_target`; no `github.event.*` in `run:`.
+- Concurrency deliberate: PR-triggered cancel-in-progress true, release false.
+- Release uses `actions/attest` directly (provenance from `subject-checksums`), with
+  id-token + attestations write scoped to create-release only; signing secrets scoped to
+  the protected `environment: release`.
+- scorecard.yml matches the official OpenSSF template.
+- All pinned third-party actions run on **node24** — no runtime-deprecation exposure.
+- Repo settings verified via API: **immutable releases ON** (every release since v1.5.0
+  reports `immutable: true`; the softprops/action-gh-release create-with-assets flow is
+  compatible), secret scanning + push protection + Dependabot security updates enabled.
+  The old "enable immutable releases" Optional item is **resolved — do not re-report**.
 
-**Version currency verified 2026-07-16 (pin = latest unless noted):**
-checkout v7.0.0, setup-java **v5.3.0** (latest v5.5.0 — minor lag, Dependabot), gradle/actions v6.2.0, upload-artifact v7.0.1, download-artifact v8.0.1, dependency-review v5.0.0, actions/attest v4.1.1, gh-release **v3.0.1** (latest v3.0.2 — patch lag), scorecard-action v2.4.3 (latest; the v5.x is the *CLI* ossf/scorecard, NOT the action), codeql-action v4.36.3, junit-report v6.4.2, jacoco-report v1.8.0, paths-filter v4.0.2.
-- Note: actions/checkout backported "safer pull_request_target defaults" to all majors on 2026-07-16 — **no impact** here (no pull_request_target, already on v7).
+**Structural gaps that keep recurring (check these first on re-audit):**
+1. **Dependabot has a blind spot on the composite action.** `dependabot.yml` uses
+   `directory: "/"` for github-actions, which per GitHub docs only covers
+   `.github/workflows` + a *root* `action.yml`. `.github/actions/gradle-setup/action.yml`
+   has therefore **never** received a Dependabot bump (confirmed via `git log` on the
+   file), so its pins silently rot while every workflow pin sits at latest. Fix is
+   `directories: ["/", "/.github/actions/gradle-setup"]`. If a pin looks stale, check
+   whether it lives in the composite action before blaming the cooldown window.
+2. **Scorecard Signed-Releases scores 0** despite provenance being published. Scorecard
+   only inspects *release assets* for `*.intoto.jsonl` / `*.sigstore.json` / `*.sig` etc.;
+   attestations stored in the GitHub attestations API (and the auto release attestation
+   from immutable releases) are invisible to it. Fix: capture
+   `steps.<attest>.outputs.bundle-path` and attach it as a release asset.
 
-**Resolved since 2026-07-02:**
-- Should-fix `retry-on-snapshot-warnings` in dependency-review.yml — **adopted** (true + 600s timeout, lines 34-35).
-- Optional ANDROID_KEYSTORE_* into protected environment — **adopted** (`environment: release`).
+**Version currency verified 2026-09-06 (pin = latest unless noted):**
+checkout v7.0.1, upload-artifact v7.0.1, download-artifact v8.0.1,
+dependency-review v5.0.0, actions/attest v4.2.2, softprops/action-gh-release v3.0.3,
+ossf/scorecard-action v2.4.4 (Scorecard core v5.5.0), codeql-action v4.37.9,
+mikepenz/action-junit-report v6.5.0, madrapps/jacoco-report v1.8.0,
+dorny/paths-filter v4.0.3, gradle/actions v6.3.0 in build.yml + dependency-submission.yml.
+Stale, both in the composite action: **setup-java v5.3.0** (latest v6.0.0, 2026-08-24)
+and **gradle/actions/setup-gradle v6.2.0** (latest v6.3.0, 2026-08-02).
 
-**Open findings (2026-07-16) — all Optional, carried:**
-- Enable repo-level **immutable releases** (GA 2025-10-28) — repo config, not workflow; complements attest with tag/asset immutability + auto release attestations.
-- No SBOM attestation; actions/attest v4 supports `sbom-path` directly.
-- (Very optional / third-party, not GitHub/OpenSSF-mandated) step-security/harden-runner egress filtering.
+**gradle/actions v6.3.0 is the one that matters:** it fixes the Windows
+"Path Validation Error" cache-save defect that build.yml and release.yml work around with
+`cache-disabled: ${{ matrix.os == 'windows-latest' }}`. Once the composite is on v6.3.0
+those workarounds (and their long comments) are obsolete.
 
-**Why:** This agent (bp-ci currency lens) verifies CI rules still match *current* upstream guidance and surfaces newly-recommended controls. rv-build covers the same files from a project-rules angle.
+**Open findings (2026-09-06) — Optional, carried:**
+- No SBOM attestation; `actions/attest` v4.2.2 takes `sbom-path` directly.
+- README advertises provenance but gives consumers no `gh attestation verify` recipe —
+  GitHub's own guidance is that attestations only pay off if verified.
+- CodeQL default setup is configured for **`actions` language only**, not `java-kotlin`,
+  so app code gets no SAST (Scorecard still scores SAST 10 off the Scorecard SARIF).
+  Repo config, and autobuild on a KMP Gradle build is not free.
 
-**How to apply:** On re-audit, re-verify major versions, check whether Optional items were adopted, and trust current file state over this snapshot.
+**Why:** This agent (bp-ci currency lens) verifies CI rules still match *current* upstream
+guidance and surfaces newly-recommended controls. rv-ci covers the same files from a
+project-rules angle.
+
+**How to apply:** On re-audit, re-resolve every pinned SHA to a tag (`gh api
+repos/<r>/git/refs/tags`), diff against `releases/latest`, and check the composite action
+separately from the workflows. Trust current file/API state over this snapshot.

--- a/.claude/agent-memory/bp-compose/currency-baseline.md
+++ b/.claude/agent-memory/bp-compose/currency-baseline.md
@@ -1,6 +1,6 @@
 ---
 name: currency-baseline
-description: Upstream-currency verification of kmp-ledger Compose UI + Navigation 3 against pinned CMP 1.12.0 / nav3 runtime 1.1.7 + ui 1.1.1 / material3 1.12.0-alpha03, last re-checked 2026-09-06
+description: Upstream-currency verification of kmp-ledger Compose UI + Navigation 3 (incl. theme, shared components, Android/desktop/iOS entry points) against pinned CMP 1.12.0 / nav3 runtime 1.1.7 + ui 1.1.1 / material3 1.12.0-alpha03, last re-checked 2026-09-06
 metadata:
   type: project
 ---
@@ -63,6 +63,13 @@ never as staleness.
   the marker class is a leftover. Removable. Keep `ExperimentalMaterial3AdaptiveApi`
   — `rememberListDetailSceneStrategy` and the `ListDetailSceneStrategy` companion
   are still experimental in adaptive 1.3.0-beta02.
+- **`ExperimentalMaterial3AdaptiveApi` is still required in BOTH places** (re-checked
+  2026-09-06 against the pinned `adaptive-navigation3-1.3.0-beta02-sources.jar`):
+  `App.kt:40` for `rememberListDetailSceneStrategy` (`@ExperimentalMaterial3AdaptiveApi`
+  on the fun, `ListDetailSceneStrategy.kt:69`) and `PostingModule.kt:32` for
+  `ListDetailSceneStrategy.listPane()/detailPane()` — the marker sits on the **class**
+  (line 128), so companion access inherits it. Not a finding; do not propose removal
+  without re-reading that sources jar.
 - `@OptIn(ExperimentalMaterial3Api::class)` on all four screens
   (`PostingListScreen.kt:57`, `PostingEditScreen.kt:77`, `PostingDetailsScreen.kt:87`,
   `SettingsScreen.kt:72`) — the only experimental API they used was `TopAppBar`, which
@@ -91,6 +98,40 @@ never as staleness.
   latest *stable*, and 1.2.0 is source-breaking. Re-evaluate when nav3-ui 1.2.0 ships
   stable or the next CMP bump forces it.
 
+## Open guideline gap — no composable in the repo takes a `Modifier`
+
+Grep-verified 2026-09-06: `modifier: Modifier` appears **zero** times in hand-written
+source; all 14 `@Composable` functions omit it. The Compose API guidelines make
+"Elements accept and respect a `Modifier` parameter" a MUST, echoed by
+developer.android.com/develop/ui/compose/modifiers (rev. 2026-08-14). The load-bearing
+case is `core/compose/.../LabeledField.kt:12` — public, BCV-dumped, consumed
+cross-module by `PostingDetailsScreen.kt:193` **positionally** (`LabeledField(label,
+value, MaterialTheme.typography.titleLarge)`), so inserting `modifier` as the first
+optional param (per the guideline) breaks that call site and needs `./gradlew apiDump`.
+Report as Should-fix for `LabeledField`; the screen-level ones are the screens' owner's
+call.
+
+## Platform entry points — verified current 2026-09-06
+
+- `androidApp/.../MainActivity.kt` — `ComponentActivity` + `setContent` +
+  `enableEdgeToEdge()`. `enableEdgeToEdge` is **not** deprecated in the pinned
+  androidx-activity 1.13.0 (`activity-1.13.0-sources.jar`, `EdgeToEdge.kt`), and the
+  ordering matches developer.android.com/develop/ui/compose/system/setup-e2e
+  (rev. 2026-09-02), which calls it **after** `super.onCreate`. Note the 1.13.0 KDoc
+  sample shows it *before* — docs and KDoc disagree; do not raise this as a finding.
+  targetSdk 37 ⇒ predictive back is on by default, so no manifest opt-in is needed.
+- `desktopApp/.../main.kt` — v1 `application { }` hosting a v2 `Window` is the intended
+  shape: CMP 1.12.0 `ui-desktop` ships **no** `window.v2` application entry, and neither
+  `Application_desktopKt` nor `window.v2.Window_desktopKt`/`WindowState_desktopKt`
+  carries a `Deprecated` attribute (javap-verified).
+- `iosExport/.../MainViewController.kt` — bare `ComposeUIViewController { App() }` is
+  current; the `configure` overload is optional. `iosApp/iosApp/Info.plist` has
+  `CADisableMinimumFrameDurationOnPhone` (CMP crashes without it).
+  `ContentView.swift` uses `.ignoresSafeArea()` (all regions/edges) where the JetBrains
+  template uses `.ignoresSafeArea(.all, edges: .bottom)` — **not** a finding: the app's
+  `Scaffold`+`TopAppBar` defaults consume `systemBars`, so full-screen + Compose-side
+  insets is the coherent edge-to-edge setup and mirrors Android's `enableEdgeToEdge`.
+
 ## Verified current — do not re-litigate
 
 `collectAsStateWithLifecycle` everywhere (no bare `collectAsState`); theme flow
@@ -98,8 +139,24 @@ remembered on the use case then collected with `initialValue`; no
 `LaunchedEffect(Unit)`/`(true)`; `staticCompositionLocalOf` for `LocalNavigator` with
 the trade-off documented; every `Res`-generating module pins `packageOfResClass` and
 only `core:compose` sets `publicResClass = true`; `Icons.AutoMirrored` for mirroring
-glyphs; no CMP 1.12.0 deprecations hit (no `NativeCanvas`/`NativePaint`, no `SwingPanel`
-background param) and `desktopApp` already on the `ui.window.v2` API.
+glyphs; `desktopApp` already on the `ui.window.v2` API.
+
+**CMP 1.12.0 Migration Notes sweep (2026-09-06, complete).** The release body has
+exactly one `## Migration Notes` section with three items — `NativeCanvas`/`NativePaint`
+raised to `ERROR`; `SwingPanel(background=)` deprecated; `ComposePanel`/`ComposeWindow`/
+`ComposeDialog` needing `setPreferredSize` under infinite constraints. Grep-verified:
+none of those identifiers appear in hand-written source. Corroborated by
+`docs/2026-09-04-build-warnings-cleanup.md` — a full `clean allTests --rerun-tasks`
+on these exact pins produced **zero** `w:` lines from hand-written source, so no
+WARNING-level deprecation is being hit anywhere.
+
+**Theme currency (2026-09-06).** `core/ui/.../theme/Theme.kt` is clean:
+`MaterialTheme(colorScheme, typography, content)` is not deprecated in material3
+1.12.0-alpha03 (the 3-arg overload delegates to the `MotionScheme` one; javap-verified,
+no `Deprecated` attribute), and `isSystemInDarkTheme()` is real on every target —
+foundation's skiko actual delegates to `androidx.compose.ui.SystemThemeKt
+.isUiSystemInDarkTheme`, i.e. `LocalSystemTheme`. `MaterialExpressiveTheme` exists in
+this build but adopting it is a design choice, not a currency gap.
 
 **Deferred (out of bp-compose's lane):** `LaunchedEffect`-on-boolean snackbar
 signalling and lifecycle-unaware `Channel` event collection → rv-compose;

--- a/.claude/agent-memory/bp-testing/MEMORY.md
+++ b/.claude/agent-memory/bp-testing/MEMORY.md
@@ -1,3 +1,3 @@
 # Memory Index
 
-- [Test-stack currency notes](test-stack-currency-notes.md) — v2 UI-test adoption + coroutines-test facts; the "CMP 1.11.1 / Kover 0.9.8 are latest" claims EXPIRED (now 1.12.0 / 0.9.9) — re-derive version claims before reuse
+- [Test-stack currency notes](test-stack-currency-notes.md) — v2 UI-test API confirmed still @ExperimentalTestApi at CMP 1.12.0; whole test stack at latest stable as of 2026-09-06; Robolectric SDK-37 lands in 4.17 (still beta)

--- a/.claude/agent-memory/bp-testing/test-stack-currency-notes.md
+++ b/.claude/agent-memory/bp-testing/test-stack-currency-notes.md
@@ -1,56 +1,53 @@
 ---
 name: test-stack-currency-notes
-description: Test-toolchain currency facts (coroutines-test, Compose MP v2 UI-test API, Kover). Content verified 2026-07-16 against CMP 1.11.1 / Kover 0.9.8 — BOTH PINS HAVE SINCE MOVED; re-derive before reuse
+description: Test-toolchain currency facts (coroutines-test, Compose MP v2 UI-test API, robolectric/junit/espresso). Every version claim is a dated observation verified 2026-09-06 against the artifacts — re-read the pins before reuse
 metadata:
   type: project
 ---
 
-> **STALE BASELINE — corrected 2026-09-06.** This note asserted "Compose MP 1.11.1 is
-> the latest stable" and "Kover 0.9.8 is the latest release". Both were true on
-> 2026-07-16 and are false now: the catalog pins **CMP 1.12.0** (stable, released
-> 2026-08-26) and **Kover 0.9.9**. Its old "How to apply" told the next run to diff
-> against those baselines instead of re-deriving — which is exactly how a stale number
-> survives an audit. **Read the pins from `gradle/libs.versions.toml` first; every
-> version claim below is a dated observation, not a current fact.**
+Test-stack currency facts. **Every version number below is a dated observation, not a
+standing fact.** Read `gradle/libs.versions.toml` first; where a pin differs from the
+version a claim names, treat that claim as unverified and re-derive it.
 
-Test-stack currency facts, last genuinely verified 2026-07-02 and re-verified
-2026-07-16 against the versions pinned *at that time*.
+## Verified 2026-09-06 (against the cached artifacts, not from recall)
 
-- **kotlinx-coroutines 1.11.0** (still the pinned version as of 2026-09-06, and still
-  latest stable at that date). Its only test-module change: advanced deprecation of the
-  `runTest(dispatchTimeout=...)` overloads to ERROR and removal of the long-ERROR
-  `TestCoroutineScope` APIs (PR #4604). This repo uses none of them.
-- **Compose MP v2 UI-test API** — verified against CMP 1.11.1; **not re-checked against
-  the pinned 1.12.0.** CMP 1.11.0 made the v2 test APIs the default and deprecated v1
-  `runComposeUiTest`/`runDesktopComposeUiTest`/`runSkikoComposeUiTest`. v2 lives in
-  `androidx.compose.ui.test.v2` (common) and `androidx.compose.ui.test.junit4.v2`
-  (Android rules: `createAndroidComposeRule` etc.), defaults to **StandardTestDispatcher**
-  (queued) rather than UnconfinedTestDispatcher, and adds an `effectContext` parameter.
-  The API was still `@ExperimentalTestApi` at 1.11.1 — **re-confirm on 1.12.0 before
-  asserting the opt-in is still required.**
-  Sources: https://kotlinlang.org/docs/multiplatform/whats-new-compose-111.html ,
-  https://kotlinlang.org/docs/multiplatform/compose-test.html ,
-  https://developer.android.com/develop/ui/compose/testing/migrate-v2
-- **The repo is already fully on v2** everywhere (common screen tests, DesktopUiTest's
-  `runDesktopComposeUiTest`, androidApp SmokeTest's `junit4.v2.createAndroidComposeRule`).
-  Structural, not version-dependent — do not re-flag a v1 to v2 migration.
-- coroutines-test still marks much of the module `@ExperimentalCoroutinesApi`, so the
-  blanket `@OptIn(ExperimentalCoroutinesApi::class)` on test classes using
-  `UnconfinedTestDispatcher`/`setMain` is required, not stale. (Verified for 1.11.0, the
-  pinned version — re-check only if that pin moves.)
-- Audit outcome 2026-07-02 and 2026-07-16: **zero upstream-currency gaps** in the test
-  suites. setMain paired with resetMain in every class; no legacy
-  `runBlockingTest`/`TestCoroutineDispatcher`; no real-time waits (uses `waitForIdle` /
-  `waitUntilExactlyOneExists`). This verdict predates the CMP 1.12.0 bump.
+- **CMP v2 UI-test API is STILL `@ExperimentalTestApi` at Compose Multiplatform 1.12.0.**
+  Evidence: `javap -v` on `org.jetbrains.compose.ui:ui-test-desktop:1.12.0` shows
+  `Landroidx/compose/ui/test/ExperimentalTestApi;` directly on
+  `androidx.compose.ui.test.v2.ComposeUiTest_skikoKt.runComposeUiTest` and on
+  `ComposeUiTest_desktopKt.runDesktopComposeUiTest`. The v2 signature is unchanged from
+  1.11.1: `(effectContext, runTestContext, testTimeout, block: suspend ComposeUiTest.() -> Unit)`,
+  default dispatcher **StandardTestDispatcher**. kotlinlang.org/docs/multiplatform/compose-test.html
+  still shows `@OptIn(ExperimentalTestApi::class)` + `v2.runComposeUiTest` as the recommended form.
+  → The repo's per-class `@OptIn(ExperimentalTestApi::class)` is **required**, not stale.
+- **coroutines-test 1.11.0**: `UnconfinedTestDispatcher()`, `Dispatchers.setMain`,
+  `Dispatchers.resetMain`, `TestScope.advanceUntilIdle/runCurrent` are all still
+  `@ExperimentalCoroutinesApi`. `TestCoroutineScheduler` and its `advanceUntilIdle()` are
+  NOT experimental. Only deprecations in the module are the `dispatchTimeoutMs` `runTest`
+  overloads (ERROR since 1.11.0) — unused here.
+- **Robolectric 4.16.1 tops out at SDK 36** (`DefaultSdkProvider` highest entry = 36 /
+  Android 16). So `@Config(sdk = [36])` in `core/test/.../PlatformComposeUiTest.android.kt`
+  is a live constraint, not stale, while `android-sdk-compile = 37`.
+  Robolectric **4.17-beta-1 (2026-07-15) is the release that adds SDK 37** — still beta as of
+  2026-09-06 (latest prerelease 4.17-beta-4, 2026-08-23; latest *stable* 4.16.1, 2026-01-21).
+  When 4.17 goes stable, the `@Config(sdk = [36])` pin and its comment can be dropped.
+- Latest-stable check 2026-09-06: kotlinx-coroutines **1.11.0** = pinned; CMP **1.12.0** =
+  pinned (released 25 Aug 2026); robolectric **4.16.1** = pinned; junit **4.13.2** = pinned
+  (final JUnit 4 release); espresso-core **3.7.0** = pinned; androidx.test.ext:junit **1.3.0**
+  = pinned; bcprov-jdk18on **1.85.2** = pinned. Whole test stack was at latest stable.
+- **Audit outcome 2026-09-06: zero upstream-currency gaps.** Repo is fully on the v2 test
+  API everywhere (common screen tests, `runDesktopComposeUiTest`, androidApp
+  `junit4.v2.createAndroidComposeRule`); `setMain` paired with `resetMain` in every class;
+  no `runBlockingTest`/`TestCoroutineDispatcher`/`Thread.sleep`/`delay` real-time waits;
+  only non-deprecated `kotlin.test` assertions (`assertEquals/True/False/Is/Null/NotNull/
+  NotEquals/Same/FailsWith`). Do not re-flag a v1→v2 migration; it is already done.
 
-**Why:** the previous version of this note is the clearest example in the repo of how a
-currency memory fails — it was accurate when written, framed dated observations as
-standing facts, and instructed the next run to trust them. A note that says "X is the
-latest" is wrong the moment X ships a successor.
+**Why:** an earlier version of this note framed dated observations as standing facts
+("CMP 1.11.1 is latest", "Kover 0.9.8 is latest") and told the next run to diff against
+those baselines — which is exactly how a stale number survives an audit.
 
-**How to apply:** read the pinned `compose-multiplatform`, `kotlinx-coroutines` and
-`kover` versions from `gradle/libs.versions.toml` and compare them to the versions each
-claim above names. Where they differ, treat that claim as **unverified** and re-derive it
-from the release notes or the pinned artifact's own sources before reusing it. When you
-re-derive one, correct this note in place — writes under `.claude/agent-memory/` are
-permitted.
+**How to apply:** re-read the pins, then re-derive any claim whose named version moved.
+Cheapest re-derivation path (used above): the Gradle cache under
+`$GRADLE_USER_HOME/caches/modules-2/files-2.1/` already holds the resolved jars/sources —
+`javap -v` on a class file shows opt-in markers directly, which beats reading docs prose.
+Correct this note in place when you re-derive; writes under `.claude/agent-memory/` are permitted.


### PR DESCRIPTION
The memory-audit rule landed in #29; this is the first set of corrections the
agents produced by actually applying it. Documentation-only — no build or app
code is touched.

Four notes were carrying dated observations as standing facts, and one was
wrong about a pin that had moved.

**bp-android** — the note claimed AGP 9.1.0 while the catalog pins 9.1.1, so
every run reasoned from a version no longer in the build. Adds the facts that
were previously assumed: AGP 9.1.1 supports API 37 (so "compileSdk exceeds AGP"
stops being re-filed), the Play target-API rule is in force since 2026-08-31,
and the 16 KB page-size deadline applies because `BundledSQLiteDriver` ships
`libsqliteJni.so` — ELF program headers checked, already 16 KB aligned. Also
records that the sole Gradle-managed device is API 30 because ATD images exist
only there, so API-37 behavior changes aren't covered by it. The backup note now
says why both rule files are load-bearing (some OEMs read `allowBackup="false"`
as cloud-only) and pre-empts the `path`-is-required nit that AOSP tolerates.

**bp-ci** — names the two gaps that kept resurfacing as if new:

1. Dependabot's `github-actions` entry uses `directory: "/"`, which never covers
   `.github/actions/gradle-setup/action.yml`. That file has never received a
   bump and holds the repo's only two stale pins — including gradle/actions
   6.3.0, which fixes the Windows cache-save defect that `build.yml` and
   `release.yml` still work around.
2. Scorecard's Signed-Releases scores 0 not for lack of provenance but because
   it only inspects release *assets*, and the attestation bundle isn't attached
   as one.

Immutable releases were verified ON via the API, so that Optional item is closed
rather than carried a fourth time.

**bp-compose** — confirms the material3-adaptive and test opt-ins are still
required at the pinned versions instead of leaving them "re-check before
asserting", and records entry-point verification (`enableEdgeToEdge` not
deprecated in activity 1.13.0; the desktop v1-application-hosting-v2-Window
shape is intended; the iOS `ignoresSafeArea` divergence from the template is
coherent). Adds the one real gap the pass found: no composable in the repo takes
a `Modifier`, and `LabeledField` is called positionally cross-module, so fixing
it needs `apiDump`.

**bp-testing** — replaces the stale-baseline banner with re-derived facts. The
v2 UI-test API is still `@ExperimentalTestApi` at CMP 1.12.0 (javap-verified),
so the per-class opt-ins are required; Robolectric tops out at SDK 36 until 4.17
leaves beta, so `@Config(sdk = [36])` is a live constraint. Also records the
cheap re-derivation path the pass used — `javap` over the already-resolved jars
in the Gradle cache beats reading docs prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D5ERoAm7SzSDEupb9BPc4w
