### PR TITLE
docs: pin the signer workflow and make the offline verify recipe actually offline

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,13 +552,29 @@ sha256sum -c SHA256SUMS
 # 2. Verify SLSA build provenance for a binary you downloaded.
 #    The attestation's subjects are the files listed *in* SHA256SUMS, so pass
 #    one of those files here — not SHA256SUMS itself.
-gh attestation verify ledger-1.8.0.msi --repo aoreshkov/kmp-ledger
+#    --signer-workflow pins the identity to this repo's release workflow; with
+#    --repo alone, any workflow in the repo would satisfy the check.
+gh attestation verify ledger-1.8.0.msi \
+  --repo aoreshkov/kmp-ledger \
+  --signer-workflow aoreshkov/kmp-ledger/.github/workflows/release.yml
 
-# Offline / air-gapped: verify against the bundle attached to the release
-# instead of the GitHub API.
+# 3. Without the attestations API: verify against the bundle attached to the
+#    release. Sigstore trust material is still fetched over the network.
 gh attestation verify ledger-1.8.0.msi \
   --bundle SHA256SUMS.intoto.jsonl \
-  --repo aoreshkov/kmp-ledger
+  --repo aoreshkov/kmp-ledger \
+  --signer-workflow aoreshkov/kmp-ledger/.github/workflows/release.yml
+
+# 4. Fully offline: capture the Sigstore trusted root while still online, then
+#    verify with no network access at all. Regenerate trusted_root.jsonl
+#    whenever you import newly signed material — it carries no expiry, so a
+#    stale copy keeps accepting keys that have since been rotated or revoked.
+gh attestation trusted-root > trusted_root.jsonl   # online, ahead of time
+gh attestation verify ledger-1.8.0.msi \
+  --bundle SHA256SUMS.intoto.jsonl \
+  --custom-trusted-root trusted_root.jsonl \
+  --repo aoreshkov/kmp-ledger \
+  --signer-workflow aoreshkov/kmp-ledger/.github/workflows/release.yml
 ```
 
 ### Android release signing


### PR DESCRIPTION
Follow-up to #33, which added the `gh attestation verify` recipe. The recipe works, but it under-verifies and it overpromises. Both defects were found re-auditing it against `gh` 2.95.0's own help and GitHub's offline-verification docs.

### It verified with `--repo` alone

`gh attestation verify --help` is explicit that the actor identity is the repository **and** the workflow that produced the attestation:

> The more precisely you specify the identity, the more control you will have over the security guarantees offered by the verification process. Ideally, the path of the signer workflow is also validated using the `--signer-workflow` or `--cert-identity` flags.

With `--repo` only, an attestation minted by *any* workflow in this repo holding `attestations: write` satisfies the check. That is one workflow today, but that is a property of our configuration — not something the consumer's verification enforces. Now pinned to `.github/workflows/release.yml`.

### The `--bundle` variant was labelled "offline / air-gapped"

It is not. `--bundle` drops the attestations API lookup — which is what the comment's second half claimed, and that part was right — but Sigstore trust material still comes over the network. An actually air-gapped consumer following that line hits a failure.

[Verifying attestations offline](https://docs.github.com/actions/security-for-github-actions/using-artifact-attestations/verifying-attestations-offline) prescribes both halves, and `gh`'s flag help agrees (`--custom-trusted-root`: *"Path to a trusted_root.jsonl file; likely for offline verification"*). So step 3 is relabelled for what it actually does, and a step 4 is added that is genuinely offline — `gh attestation trusted-root` captured while online, replayed through `--custom-trusted-root` — carrying the caveat that the trusted root has no expiry, so a stale copy keeps accepting key material rotated or revoked since it was written.

### Notes

- Documentation only. No workflow change, no dependency, no public API change — no `apiDump` needed.
- Considered and left out: `--deny-self-hosted-runners`. Every release job runs on GitHub-hosted runners so we could honestly offer it, but it adds a fourth flag to every command for a guarantee `--signer-workflow` already implies here. Worth revisiting if a self-hosted runner is ever introduced.
- Unchanged, and still correct: with `subject-checksums`, the attestation's subjects are the files listed *in* `SHA256SUMS`, not that file — so `gh attestation verify` takes a downloaded binary.
- `Signed-Releases` still reads 0 on Scorecard because #33 postdates the last tag. The next tagged release verifies both that fix and this recipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015KocvB4f5fgcqghjoeQFdi
