### PR TITLE
build(kover): exclude Room codegen and aggregate the desktop test's coverage

### DIFF
--- a/build-logic/src/main/kotlin/ledger.kotlin.multiplatform.gradle.kts
+++ b/build-logic/src/main/kotlin/ledger.kotlin.multiplatform.gradle.kts
@@ -44,6 +44,10 @@ kover {
                 classes(
                     "*ComposableSingletons*",
                     "*_Factory",
+                    // Room KSP output (`*_Impl` DAO/database implementations and the
+                    // generated `LedgerDatabaseConstructor` actual).
+                    "*_Impl*",
+                    "*DatabaseConstructor",
                     "*\$\$serializer",
                     // Compose `Res` accessors; each module pins its own package via
                     // `packageOfResClass` under `app.oreshkov.ledger.*.resources`.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,12 @@ dependencies {
     kover(project(":feature:posting:impl"))
     kover(project(":feature:settings:api"))
     kover(project(":feature:settings:impl"))
+
+    // An app module, aggregated on purpose: DesktopUiTest boots the real App() over
+    // a real in-memory Room DB, DataStore, Koin graph and NavDisplay. Without this
+    // entry its execution data is discarded and none of the library code it
+    // exercises is credited.
+    kover(project(":desktopApp"))
 }
 
 kover {
@@ -38,12 +44,23 @@ kover {
                 classes(
                     "*ComposableSingletons*",
                     "*_Factory",
+                    // Room KSP output: the generated `*_Impl` DAO/database
+                    // implementations plus the `LedgerDatabaseConstructor` actual.
+                    // Generated code, same rationale as `*_Factory` (Koin) and
+                    // `$$serializer` (kotlinx.serialization) either side of it.
+                    "*_Impl*",
+                    "*DatabaseConstructor",
                     "*\$\$serializer",
                     // Compose `Res` accessors. Each module pins its own package via
                     // `packageOfResClass`, so this tracks `app.oreshkov.ledger.*.resources`
                     // rather than the `*.generated.resources` default.
                     "app.oreshkov.ledger.*.resources.*",
                     "*.compose.resources.*",
+                    // :desktopApp is aggregated above so DesktopUiTest's coverage
+                    // counts; its own entry points carry no logic, so they stay out
+                    // of the denominator.
+                    "app.oreshkov.ledger.MainKt",
+                    "app.oreshkov.ledger.LedgerApp",
                     // DI wiring lives in *.di packages; validated by Koin verify(),
                     // not by execution — exclude so coverage reflects real logic.
                     "*.di.*"

--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     alias(libs.plugins.kotlin.compose.compiler)
     alias(libs.plugins.koin.compiler)
     alias(libs.plugins.compose.hot.reload)
+    alias(libs.plugins.kover)
 }
 
 dependencies {


### PR DESCRIPTION
Two config-only fixes to the coverage report. No test code, no floor changes.

## 1. Room-generated code was 27.6% of the denominator

`PostingDao_Impl`, `LedgerDatabase_Impl` and the generated `LedgerDatabaseConstructor`
actual accounted for **237 of 860 lines** in the aggregate report. `core:database` read
56.5% line coverage purely because of them, which is why it carries no `koverVerify` rule.

Room marks its output `@javax.annotation.processing.Generated`, which is
`@Retention(SOURCE)` — not present in the bytecode, so Kover's `annotatedBy` filter cannot
see it. The exclusion is by name pattern instead, next to the existing `*_Factory` (Koin)
and `$$serializer` (kotlinx.serialization) entries, and is added in **both** the root
aggregate and `ledger.kotlin.multiplatform.gradle.kts` per the keep-in-sync rule.

## 2. `DesktopUiTest`'s coverage was being discarded

`:desktopApp` had no Kover plugin and was absent from the root `kover(project(...))` list.
`DesktopUiTest` boots the real `App()` over a real in-memory Room DB, DataStore, Koin
graph and `NavDisplay` — and already runs on every CI build via `check` — but none of the
library code it exercised was credited.

Aggregating it credits:

- `TopLevelDestination` — 0/5 → **5/5 lines**
- `PostingListScreenKt` — 41/50 → **49/50 lines**, 17/40 → **31/40 branches**
- smaller branch gains in `SettingsScreenKt` and `PostingEditScreenKt`

`MainKt` and `LedgerApp` are excluded: framework entry points carry no business logic, so
they would only add permanently-red lines.

## Result

|  | before | after | floor |
|---|---|---|---|
| line | 91.86% (790/860) | **94.07%** (587/624) | 88 |
| branch | 64.26% (205/319) | **68.73%** (211/307) | 60 |
| instruction | 87.85% (7078/8057) | **91.32%** (6313/6913) | 84 |

Floors are deliberately untouched — raising them is a follow-up once the remaining real
gaps (`Slf4jWriter`, the VM-wired `PostingDetailsScreen`, `LedgerTheme`) are covered.

## Verification

- `./gradlew check` — passes
- `./gradlew koverXmlReport koverVerify` — passes
- `./gradlew :koverXmlReport --dry-run` now lists `:desktopApp:test` in the graph

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015KocvB4f5fgcqghjoeQFdi
