### PR TITLE
test: cover the last untested logic the coverage report could see

### DIFF
--- a/core/common/src/jvmTest/kotlin/app/oreshkov/ledger/core/common/util/PlatformLogWriterTest.kt
+++ b/core/common/src/jvmTest/kotlin/app/oreshkov/ledger/core/common/util/PlatformLogWriterTest.kt
@@ -1,0 +1,71 @@
+package app.oreshkov.ledger.core.common.util
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
+import co.touchlab.kermit.Severity
+import org.slf4j.LoggerFactory
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The JVM `actual` writes through SLF4J, so the assertions go through logback — the binding
+ * already on this source set's runtime classpath — rather than a fake. `ListAppender` attached
+ * to one named logger keeps the capture scoped to this test.
+ */
+class PlatformLogWriterTest {
+
+    private val tag = "PlatformLogWriterTest"
+    private lateinit var logger: Logger
+    private lateinit var appender: ListAppender<ILoggingEvent>
+
+    @BeforeTest
+    fun setUp() {
+        logger = LoggerFactory.getLogger(tag) as Logger
+        // The writer emits at debug for Verbose/Debug; logback's default root level would
+        // swallow those on some configurations.
+        logger.level = Level.TRACE
+        appender = ListAppender<ILoggingEvent>().apply { start() }
+        logger.addAppender(appender)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        logger.detachAppender(appender)
+        appender.stop()
+    }
+
+    @Test
+    fun providesExactlyOneWriter() {
+        assertEquals(1, getPlatformLogWriters().size)
+    }
+
+    @Test
+    fun mapsEverySeverityOntoAnSlf4jLevel() {
+        val writer = getPlatformLogWriters().single()
+
+        Severity.entries.forEach { severity ->
+            writer.log(severity, "message", tag, null)
+        }
+
+        assertEquals(
+            listOf(Level.DEBUG, Level.DEBUG, Level.INFO, Level.WARN, Level.ERROR, Level.ERROR),
+            appender.list.map { it.level },
+        )
+    }
+
+    @Test
+    fun forwardsMessageAndThrowable() {
+        val cause = IllegalStateException("boom")
+
+        getPlatformLogWriters().single().log(Severity.Error, "message", tag, cause)
+
+        val event = appender.list.single()
+        assertEquals("message", event.message)
+        assertEquals(tag, event.loggerName)
+        assertEquals("boom", event.throwableProxy?.message)
+    }
+}

--- a/core/navigation/src/commonTest/kotlin/app/oreshkov/ledger/core/navigation/LocalNavigatorTest.kt
+++ b/core/navigation/src/commonTest/kotlin/app/oreshkov/ledger/core/navigation/LocalNavigatorTest.kt
@@ -1,0 +1,33 @@
+package app.oreshkov.ledger.core.navigation
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.v2.runComposeUiTest
+import app.oreshkov.ledger.core.test.PlatformComposeUiTest
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalTestApi::class)
+class LocalNavigatorTest : PlatformComposeUiTest() {
+
+    @Test
+    fun readingCurrent_withoutAProvider_failsWithADiagnosticMessage() {
+        var failure: Throwable? = null
+        try {
+            runComposeUiTest { setContent { LocalNavigator.current } }
+        } catch (e: Throwable) {
+            failure = e
+        }
+
+        val thrown = assertNotNull(
+            failure,
+            "expected reading LocalNavigator.current without a provider to fail",
+        )
+        // Compose may wrap a composition failure, so match anywhere in the cause chain.
+        val messages = generateSequence(thrown) { it.cause }.mapNotNull { it.message }.toList()
+        assertTrue(
+            messages.any { "No Navigator provided" in it },
+            "expected 'No Navigator provided' in the cause chain, got: $messages",
+        )
+    }
+}

--- a/core/ui/src/commonTest/kotlin/app/oreshkov/ledger/core/ui/theme/ThemeTest.kt
+++ b/core/ui/src/commonTest/kotlin/app/oreshkov/ledger/core/ui/theme/ThemeTest.kt
@@ -1,0 +1,57 @@
+package app.oreshkov.ledger.core.ui.theme
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.v2.runComposeUiTest
+import app.oreshkov.ledger.core.model.settings.ThemeMode
+import app.oreshkov.ledger.core.test.PlatformComposeUiTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalTestApi::class)
+class ThemeTest : PlatformComposeUiTest() {
+
+    @Test
+    fun lightMode_appliesTheLightColorScheme() = runComposeUiTest {
+        var primary = Color.Unspecified
+
+        setContent {
+            LedgerTheme(ThemeMode.LIGHT) { primary = MaterialTheme.colorScheme.primary }
+        }
+
+        assertEquals(Purple40, primary)
+    }
+
+    @Test
+    fun darkMode_appliesTheDarkColorScheme() = runComposeUiTest {
+        var primary = Color.Unspecified
+
+        setContent {
+            LedgerTheme(ThemeMode.DARK) { primary = MaterialTheme.colorScheme.primary }
+        }
+
+        assertEquals(Purple80, primary)
+    }
+
+    @Test
+    fun systemMode_defersToTheOsSetting() = runComposeUiTest {
+        var fromSystemMode = Color.Unspecified
+        var fromDefaultOverload = Color.Unspecified
+
+        setContent {
+            LedgerTheme(ThemeMode.SYSTEM) { fromSystemMode = MaterialTheme.colorScheme.primary }
+            // The no-argument overload defaults to `isSystemInDarkTheme()`, which is exactly what
+            // ThemeMode.SYSTEM is specified to defer to. Comparing the two asserts the deferral
+            // without pinning the host's dark-mode setting.
+            LedgerTheme { fromDefaultOverload = MaterialTheme.colorScheme.primary }
+        }
+
+        assertEquals(fromDefaultOverload, fromSystemMode)
+        assertTrue(
+            fromSystemMode == Purple40 || fromSystemMode == Purple80,
+            "unexpected scheme: $fromSystemMode",
+        )
+    }
+}

--- a/feature/posting/impl/src/commonTest/kotlin/app/oreshkov/ledger/feature/posting/impl/PostingDetailsScreenTest.kt
+++ b/feature/posting/impl/src/commonTest/kotlin/app/oreshkov/ledger/feature/posting/impl/PostingDetailsScreenTest.kt
@@ -3,20 +3,43 @@ package app.oreshkov.ledger.feature.posting.impl
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.test.waitUntilExactlyOneExists
+import app.oreshkov.ledger.core.domain.DeletePostingUseCase
+import app.oreshkov.ledger.core.domain.GetPostingUseCase
+import app.oreshkov.ledger.core.test.FakePostingRepository
 import app.oreshkov.ledger.core.test.PlatformComposeUiTest
 import app.oreshkov.ledger.core.test.posting
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-@OptIn(ExperimentalTestApi::class)
+@OptIn(ExperimentalTestApi::class, ExperimentalCoroutinesApi::class)
 class PostingDetailsScreenTest : PlatformComposeUiTest() {
+
+    // The VM-wired tests below drive viewModelScope, which dispatches on Main.
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(StandardTestDispatcher())
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
 
     @Test
     fun errorState_showsErrorMessageAndRetryButton() = runComposeUiTest {
@@ -151,5 +174,60 @@ class PostingDetailsScreenTest : PlatformComposeUiTest() {
             )
         }
         onNodeWithTag("loading").assertIsDisplayed()
+    }
+
+    @Test
+    fun deleteConfirmed_emitsDeletedEvent() = runComposeUiTest {
+        val repository = FakePostingRepository().apply { seed(posting()) }
+        val viewModel = PostingDetailsViewModel(
+            GetPostingUseCase(repository),
+            DeletePostingUseCase(repository),
+            postingId = "1",
+        )
+        var deleted = false
+
+        setContent {
+            PostingDetailsScreen(
+                onNavigateBack = {},
+                onEditClick = {},
+                onDeleted = { deleted = true },
+                viewModel = viewModel,
+            )
+        }
+
+        waitUntilExactlyOneExists(hasText("Groceries"))
+        onNodeWithContentDescription("Delete Posting").performClick()
+        onNodeWithText("Delete").performClick()
+
+        waitUntil { deleted }
+        assertEquals(listOf(posting()), repository.deletedPostings)
+    }
+
+    @Test
+    fun deleteFailure_showsSnackbar() = runComposeUiTest {
+        val repository = FakePostingRepository().apply { seed(posting()) }
+        val viewModel = PostingDetailsViewModel(
+            GetPostingUseCase(repository),
+            DeletePostingUseCase(repository),
+            postingId = "1",
+        )
+        var deleted = false
+
+        setContent {
+            PostingDetailsScreen(
+                onNavigateBack = {},
+                onEditClick = {},
+                onDeleted = { deleted = true },
+                viewModel = viewModel,
+            )
+        }
+
+        waitUntilExactlyOneExists(hasText("Groceries"))
+        repository.failNextWrite = true
+        onNodeWithContentDescription("Delete Posting").performClick()
+        onNodeWithText("Delete").performClick()
+
+        waitUntilExactlyOneExists(hasText("Failed to delete. Please try again."))
+        assertFalse(deleted, "a failed delete must not report the posting as deleted")
     }
 }


### PR DESCRIPTION
Follow-up to #40. That PR made the coverage report honest; this one closes the real gaps
it exposed. Four tests, no production-code changes, no floor changes.

## `Slf4jWriter` — the only branching production logic with zero coverage

`core:common`'s JVM `actual` maps five Kermit `Severity` values onto four SLF4J levels, and
nothing exercised it. New `jvmTest` source set, asserted through logback's `ListAppender` —
the binding already on that source set's runtime classpath — rather than a fake, plus the
throwable pass-through.

## `PostingDetailsScreen` — the one screen with no VM-wired test

`PostingEditScreen` and `SettingsScreen` already have tests that drive the outer,
ViewModel-wired composable; `PostingDetailsScreen` only had `PostingDetailsContent` tests.
Two new cases run the real `PostingDetailsViewModel` over `FakePostingRepository` through
both delete outcomes, which also covers the `deletedEvent` / `deleteFailedEvent`
`LaunchedEffect` collectors. The class needed `Dispatchers.setMain(StandardTestDispatcher())`,
matching `PostingEditScreenTest`.

## `LedgerTheme` — `ThemeMode` resolution had no test at all

`LIGHT` and `DARK` assert the resolved `MaterialTheme.colorScheme`. `SYSTEM` is asserted
against the no-argument `LedgerTheme` overload rather than a hardcoded scheme, so the test
does not pin the host's dark-mode setting.

## `LocalNavigator` — the missing-provider error

Matched across the cause chain, since Compose may wrap a composition failure.

## Result

|  | after #40 | this PR | floor |
|---|---|---|---|
| line | 94.07% (587/624) | **98.88%** (617/624) | 88 |
| branch | 68.73% (211/307) | **77.20%** (237/307) | 60 |
| instruction | 91.32% (6313/6913) | **98.50%** (6809/6913) | 84 |

**Seven uncovered lines remain in the whole codebase**, and all of them are unreachable
from a test: five Compose codegen artifacts (`$default` / lambda trailing lines in
`ThemeKt` and the three screen files) and `getPlatformLogWriters()`'s Android `actual`,
which would need Robolectric in `core:common` for one line of `listOf(LogcatWriter())`.

Floors stay where they are — raising them is a separate change, and the branch floor
should stay modest regardless: 62% of the report's branches are Compose `$changed` /
`$default` bitmask plumbing.

## Verification

- `./gradlew check` — passes
- `./gradlew koverXmlReport koverVerify` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015KocvB4f5fgcqghjoeQFdi
